### PR TITLE
Don't automatically set foldmethod to syntax

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -198,7 +198,6 @@ syn match typeScriptLogicSymbols "\(&&\)\|\(||\)"
 " typeScriptFold Function {{{
 
 function! TypeScriptFold()
-setl foldmethod=syntax
 setl foldlevelstart=1
 syn region foldBraces start=/{/ end=/}/ transparent fold keepend extend
 


### PR DESCRIPTION
I like to use indentation-based folding. I think it makes sense for this plugin to configure the syntax-based folding for users who do want it, but it shouldn't automatically enable syntax-based folding.
