### PR TITLE
removed cindent

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,7 +1,6 @@
 compiler typescript
 
 setlocal autoindent
-setlocal cindent
 setlocal smartindent
 setlocal indentexpr&
 


### PR DESCRIPTION
cindent setting is making coding difficult - especially while defining nested statements - a lot of backspace is required as on avg. cindent is adding 3-4 tabs.
