### PR TITLE
Remove the definition of `foldBraces` region.

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -199,7 +199,7 @@ syn match typeScriptLogicSymbols "\(&&\)\|\(||\)"
 
 function! TypeScriptFold()
 setl foldlevelstart=1
-syn region foldBraces start=/{/ end=/}/ transparent fold keepend extend
+" syn region foldBraces start=/{/ end=/}/ transparent fold keepend extend
 
 setl foldtext=FoldText()
 endfunction


### PR DESCRIPTION
Fixes a common bug in the highlighting of comments with braces:

<!-- language : ts -->
  
    function f() {
      // } { This is no longer a typeScriptLineComment but a foldBraces region.
    }

This confuses the `matchit` plugin as well.

### Update

This example actually works, to see an example of where it doesn't, see [commen below](https://github.com/leafgarland/typescript-vim/pull/18#issuecomment-27379214).
