### PR TITLE
Improve indentation suppport

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -5,4 +5,6 @@ setlocal cindent
 setlocal smartindent
 setlocal indentexpr&
 
+setlocal cino=j1J1
+
 setlocal commentstring=//\ %s


### PR DESCRIPTION
Vim comes with some built-in support for JavaScript indentation which
also works quite well for TypeScript, though it has to be enabled by
setting "j1" and "J1" in "cinoptions" (or "cino" for short).

This should remove the need for #17.
