### PR TITLE
Changed funcKeyword to 'Type' rather than 'Function'

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -250,7 +250,7 @@ if version >= 508 || !exists("did_typeScript_syn_inits")
   HiLink typeScriptIdentifier Identifier
   HiLink typeScriptRepeat Repeat
   HiLink typeScriptStatement Statement
-  HiLink typeScriptFuncKeyword Function
+  HiLink typeScriptFuncKeyword Type
   HiLink typeScriptMessage Keyword
   HiLink typeScriptDeprecated Exception
   HiLink typeScriptError Error


### PR DESCRIPTION
Currently when you write:

``` javascript
export function example(param) {
    [etc., stuff here]
}
```

The word `function` gets styled the same as the function name (`example`). Rather, the word `function` should be styled differently than the function name. I used style `Type` to match what is used in the `vim-javascript` package.
