### PR TITLE
Make it possible to add options to the compiler.

### DIFF
--- a/compiler/typescript.vim
+++ b/compiler/typescript.vim
@@ -3,6 +3,11 @@ if exists("current_compiler")
 endif
 let current_compiler = "typescript"
 
-CompilerSet makeprg=tsc\ $*\ %
+if !exists("g:typescript_compiler_options")
+  let g:typescript_compiler_options = ""
+endif
+
+
+let &l:makeprg='tsc' . g:typescript_compiler_options . ' $*  %'
 
 CompilerSet errorformat=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m


### PR DESCRIPTION
Just set somewhere (~/.vimrc, local .vimrc with
https://github.com/MarcWeber/vim-addon-local-vimrc, or somewhere else)
variable g:typescript_compiler_options to include all additional optinos
for tsc compiler.
