### PR TITLE
Fix (simplify) function highlighting and other improvements

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,2 +1,19 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo-=C
+
 compiler typescript
 setlocal commentstring=//\ %s
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" " and insert the comment leader when hitting <CR> or using "o".
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setl fo< ofu< com< cms<"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -1,4 +1,4 @@
-" Vim indent file, taken from indent/javascript.vim and java.vim
+" Vim indent file, taken from indent/java.vim
 " Language:	    Typescript
 " Maintainer:	None!  Wanna improve this?
 " Last Change:	2015 Mar 07
@@ -30,16 +30,16 @@ set cpo&vim
 function GetTypescriptIndent()
 
     " The last non-empty line
-    " let prev = prevnonblank(v:lnum-1);
+    let prev = prevnonblank(v:lnum-1)
 
     " Check if the previous line consists of a single `<variable> : <type>;`
     " declaration (e.g. in interface definitions)
-    " if getline(prev) =~ '^\s*\k+\s*:\s*.+;\s*$'
-        " return cindent(prev);
-    " endif
+    if getline(prev) =~ '^\s*\w\+\s*:.\+;\s*$'
+        return indent(prev)
+    endif
 
     " For everything else, trust cindent:
-    return cindent(v:lnum);
+    return cindent(v:lnum)
 
 endfunction
 

--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -29,6 +29,12 @@ set cpo&vim
 
 function GetTypescriptIndent()
 
+    let cind = cindent(v:lnum);
+
+    if getline(v:lnum) =~ '^\s*[{}]'
+        return cind
+    endif
+
     " The last non-empty line
     let prev = prevnonblank(v:lnum-1)
 
@@ -39,7 +45,7 @@ function GetTypescriptIndent()
     endif
 
     " For everything else, trust cindent:
-    return cindent(v:lnum)
+    return cind
 
 endfunction
 

--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -1,0 +1,19 @@
+" Vim indent file, taken from indent/javascript.vim
+" Language:	Typescript
+" Maintainer:	None!  Wanna improve this?
+" Last Change:	2015 Mar 07
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+   finish
+endif
+let b:did_indent = 1
+
+" C indenting is not too bad.
+setlocal cindent
+setlocal cinoptions+=j1,J1
+
+" empty indentexpr
+set indentexpr=
+
+let b:undo_indent = "setl cin<"

--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -1,5 +1,5 @@
-" Vim indent file, taken from indent/javascript.vim
-" Language:	Typescript
+" Vim indent file, taken from indent/javascript.vim and java.vim
+" Language:	    Typescript
 " Maintainer:	None!  Wanna improve this?
 " Last Change:	2015 Mar 07
 
@@ -9,11 +9,42 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
-" C indenting is not too bad.
-setlocal cindent
-setlocal cinoptions+=j1,J1
+" Use javascript cindent options
+setlocal cindent cinoptions& cinoptions+=j1,J1
+setlocal indentkeys&
 
-" empty indentexpr
-set indentexpr=
+" Load typescript indent function
+setlocal indentexpr=GetTypescriptIndent()
 
-let b:undo_indent = "setl cin<"
+let b:undo_indent = "setl cin< cino< indentkeys< indentexpr<"
+
+" Only define the function once
+if exists("*GetTypescriptIndent")
+    finish
+endif
+
+" Make sure we have vim capabilities
+let s:keepcpo = &cpo
+set cpo&vim
+
+function GetTypescriptIndent()
+
+    " The last non-empty line
+    " let prev = prevnonblank(v:lnum-1);
+
+    " Check if the previous line consists of a single `<variable> : <type>;`
+    " declaration (e.g. in interface definitions)
+    " if getline(prev) =~ '^\s*\k+\s*:\s*.+;\s*$'
+        " return cindent(prev);
+    " endif
+
+    " For everything else, trust cindent:
+    return cindent(v:lnum);
+
+endfunction
+
+" Restore compatibility mode
+let &cpo = s:keepcpo
+unlet s:keepcpo
+
+" vim: et

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -178,7 +178,7 @@ syntax match typeScriptDotNotation "\.style\." nextgroup=typeScriptCssStyles
 "" Code blocks
 syntax cluster typeScriptAll contains=typeScriptComment,typeScriptLineComment,typeScriptDocComment,typeScriptStringD,typeScriptStringS,typeScriptRegexpString,typeScriptNumber,typeScriptFloat,typeScriptLabel,typeScriptSource,typeScriptType,typeScriptOperator,typeScriptBoolean,typeScriptNull,typeScriptFuncKeyword,typeScriptConditional,typeScriptGlobal,typeScriptRepeat,typeScriptBranch,typeScriptStatement,typeScriptGlobalObjects,typeScriptMessage,typeScriptIdentifier,typeScriptExceptions,typeScriptReserved,typeScriptDeprecated,typeScriptDomErrNo,typeScriptDomNodeConsts,typeScriptHtmlEvents,typeScriptDotNotation,typeScriptBrowserObjects,typeScriptDOMObjects,typeScriptAjaxObjects,typeScriptPropietaryObjects,typeScriptDOMMethods,typeScriptHtmlElemProperties,typeScriptDOMProperties,typeScriptEventListenerKeywords,typeScriptEventListenerMethods,typeScriptAjaxProperties,typeScriptAjaxMethods,typeScriptFuncArg
 
-if main_syntax == "typeScript"
+if main_syntax == "typescript"
   syntax sync clear
   syntax sync ccomment typeScriptComment minlines=200
 " syntax sync match typeScriptHighlight grouphere typeScriptBlock /{/
@@ -205,7 +205,7 @@ syn region foldBraces start=/{/ end=/}/ transparent fold keepend extend
 setl foldtext=FoldText()
 endfunction
 
-au FileType typeScript call TypeScriptFold()
+au FileType typescript call TypeScriptFold()
 
 " }}}
 
@@ -314,8 +314,8 @@ endif
 syntax cluster htmltypeScript contains=@typeScriptAll,typeScriptBracket,typeScriptParen,typeScriptBlock,typeScriptParenError
 syntax cluster typeScriptExpression contains=@typeScriptAll,typeScriptBracket,typeScriptParen,typeScriptBlock,typeScriptParenError,@htmlPreproc
 
-let b:current_syntax = "typeScript"
-if main_syntax == 'typeScript'
+let b:current_syntax = "typescript"
+if main_syntax == 'typescript'
   unlet main_syntax
 endif
 

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -72,28 +72,28 @@ syntax match typeScriptFloat /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\
 " syntax match typeScriptLabel /\(?\s*\)\@<!\<\w\+\(\s*:\)\@=/
 "}}}
 "" typeScript Prototype"{{{
-syntax keyword typeScriptPrototype prototype
+syntax keyword typeScriptPrototype contained prototype
 "}}}
 " DOM, Browser and Ajax Support {{{
 """"""""""""""""""""""""
 syntax keyword typeScriptBrowserObjects window navigator screen history location
 
 syntax keyword typeScriptDOMObjects document event HTMLElement Anchor Area Base Body Button Form Frame Frameset Image Link Meta Option Select Style Table TableCell TableRow Textarea
-syntax keyword typeScriptDOMMethods createTextNode createElement insertBefore replaceChild removeChild appendChild hasChildNodes cloneNode normalize isSupported hasAttributes getAttribute setAttribute removeAttribute getAttributeNode setAttributeNode removeAttributeNode getElementsByTagName hasAttribute getElementById adoptNode close compareDocumentPosition createAttribute createCDATASection createComment createDocumentFragment createElementNS createEvent createExpression createNSResolver createProcessingInstruction createRange createTreeWalker elementFromPoint evaluate getBoxObjectFor getElementsByClassName getSelection getUserData hasFocus importNode
-syntax keyword typeScriptDOMProperties nodeName nodeValue nodeType parentNode childNodes firstChild lastChild previousSibling nextSibling attributes ownerDocument namespaceURI prefix localName tagName
+syntax keyword typeScriptDOMMethods contained createTextNode createElement insertBefore replaceChild removeChild appendChild hasChildNodes cloneNode normalize isSupported hasAttributes getAttribute setAttribute removeAttribute getAttributeNode setAttributeNode removeAttributeNode getElementsByTagName hasAttribute getElementById adoptNode close compareDocumentPosition createAttribute createCDATASection createComment createDocumentFragment createElementNS createEvent createExpression createNSResolver createProcessingInstruction createRange createTreeWalker elementFromPoint evaluate getBoxObjectFor getElementsByClassName getSelection getUserData hasFocus importNode
+syntax keyword typeScriptDOMProperties contained nodeName nodeValue nodeType parentNode childNodes firstChild lastChild previousSibling nextSibling attributes ownerDocument namespaceURI prefix localName tagName
 
 syntax keyword typeScriptAjaxObjects XMLHttpRequest
-syntax keyword typeScriptAjaxProperties readyState responseText responseXML statusText
-syntax keyword typeScriptAjaxMethods onreadystatechange abort getAllResponseHeaders getResponseHeader open send setRequestHeader
+syntax keyword typeScriptAjaxProperties contained readyState responseText responseXML statusText
+syntax keyword typeScriptAjaxMethods contained onreadystatechange abort getAllResponseHeaders getResponseHeader open send setRequestHeader
 
 syntax keyword typeScriptPropietaryObjects ActiveXObject
-syntax keyword typeScriptPropietaryMethods attachEvent detachEvent cancelBubble returnValue
+syntax keyword typeScriptPropietaryMethods contained attachEvent detachEvent cancelBubble returnValue
 
-syntax keyword typeScriptHtmlElemProperties className clientHeight clientLeft clientTop clientWidth dir href id innerHTML lang length offsetHeight offsetLeft offsetParent offsetTop offsetWidth scrollHeight scrollLeft scrollTop scrollWidth style tabIndex target title
+syntax keyword typeScriptHtmlElemProperties contained className clientHeight clientLeft clientTop clientWidth dir href id innerHTML lang length offsetHeight offsetLeft offsetParent offsetTop offsetWidth scrollHeight scrollLeft scrollTop scrollWidth style tabIndex target title
 
-syntax keyword typeScriptEventListenerKeywords blur click focus mouseover mouseout load item
+syntax keyword typeScriptEventListenerKeywords contained blur click focus mouseover mouseout load item
 
-syntax keyword typeScriptEventListenerMethods scrollIntoView addEventListener dispatchEvent removeEventListener preventDefault stopPropagation
+syntax keyword typeScriptEventListenerMethods contained scrollIntoView addEventListener dispatchEvent removeEventListener preventDefault stopPropagation
 " }}}
 "" Programm Keywords"{{{
 syntax keyword typeScriptSource import export
@@ -165,11 +165,12 @@ if exists("typeScript_enable_domhtmlcss")
     syntax keyword typeScriptCssStyles contained marks maxHeight maxWidth minHeight minWidth opacity MozOpacity overflow overflowX overflowY verticalAlign visibility zoom cssText
     syntax keyword typeScriptCssStyles contained scrollbar3dLightColor scrollbarArrowColor scrollbarBaseColor scrollbarDarkShadowColor scrollbarFaceColor scrollbarHighlightColor scrollbarShadowColor scrollbarTrackColor
 "}}}
-" Highlight ways"{{{
-    syntax match typeScriptDotNotation "\." nextgroup=typeScriptPrototype,typeScriptDomElemAttrs,typeScriptDomElemFuncs,typeScriptHtmlElemAttrs,typeScriptHtmlElemFuncs
-    syntax match typeScriptDotNotation "\.style\." nextgroup=typeScriptCssStyles
-"}}}
 endif "DOM/HTML/CSS
+
+" Highlight ways"{{{
+syntax match typeScriptDotNotation "\."        nextgroup=typeScriptPrototype,typeScriptDomElemAttrs,typeScriptDomElemFuncs,typeScriptDOMMethods,typeScriptDOMProperties,typeScriptHtmlElemAttrs,typeScriptHtmlElemFuncs,typeScriptHtmlElemProperties,typeScriptAjaxProperties,typeScriptAjaxMethods,typeScriptPropietaryMethods,typeScriptEventListenerMethods skipwhite skipnl
+syntax match typeScriptDotNotation "\.style\." nextgroup=typeScriptCssStyles
+"}}}
 
 "" end DOM/HTML/CSS specified things""}}}
 
@@ -189,9 +190,9 @@ syntax keyword typeScriptFuncKeyword function
 "syntax match typeScriptFuncComma /,/ contained
 " syntax region typeScriptFuncBlock contained matchgroup=typeScriptFuncBlock start="{" end="}" contains=@typeScriptAll,typeScriptParensErrA,typeScriptParensErrB,typeScriptParen,typeScriptBracket,typeScriptBlock fold
 
-syn match   typeScriptBraces "[{}\[\]]"
-syn match   typeScriptParens "[()]"
-syn match   typeScriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
+syn match typeScriptBraces "[{}\[\]]"
+syn match typeScriptParens "[()]"
+syn match typeScriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
 syn match typeScriptEndColons "[;,]"
 syn match typeScriptLogicSymbols "\(&&\)\|\(||\)"
 

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -286,19 +286,19 @@ if version >= 508 || !exists("did_typeScript_syn_inits")
   HiLink typeScriptBrowserObjects Constant
 
   HiLink typeScriptDOMObjects Constant
-  HiLink typeScriptDOMMethods Exception
-  HiLink typeScriptDOMProperties Type
+  HiLink typeScriptDOMMethods Function
+  HiLink typeScriptDOMProperties Special
 
-  HiLink typeScriptAjaxObjects htmlH1
-  HiLink typeScriptAjaxMethods Exception
-  HiLink typeScriptAjaxProperties Type
+  HiLink typeScriptAjaxObjects Constant
+  HiLink typeScriptAjaxMethods Function
+  HiLink typeScriptAjaxProperties Special
 
   HiLink typeScriptFuncDef Title
   HiLink typeScriptFuncArg Special
   HiLink typeScriptFuncComma Operator
 
   HiLink typeScriptHtmlEvents Special
-  HiLink typeScriptHtmlElemProperties Type
+  HiLink typeScriptHtmlElemProperties Special
 
   HiLink typeScriptEventListenerKeywords Keyword
 

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -183,10 +183,10 @@ if main_syntax == "typeScript"
 " syntax sync match typeScriptHighlight grouphere typeScriptBlock /{/
 endif
 
-syntax keyword typeScriptFuncKeyword function contained
-syntax region typeScriptFuncDef start="function" end="\([^)]*\)" contains=typeScriptFuncKeyword,typeScriptFuncArg keepend
-syntax match typeScriptFuncArg "\(([^()]*)\)" contains=typeScriptParens,typeScriptFuncComma contained
-syntax match typeScriptFuncComma /,/ contained
+syntax keyword typeScriptFuncKeyword function
+"syntax region typeScriptFuncDef start="function" end="\(.*\)" contains=typeScriptFuncKeyword,typeScriptFuncArg keepend
+"syntax match typeScriptFuncArg "\(([^()]*)\)" contains=typeScriptParens,typeScriptFuncComma contained
+"syntax match typeScriptFuncComma /,/ contained
 " syntax region typeScriptFuncBlock contained matchgroup=typeScriptFuncBlock start="{" end="}" contains=@typeScriptAll,typeScriptParensErrA,typeScriptParensErrB,typeScriptParen,typeScriptBracket,typeScriptBlock fold
 
 syn match	typeScriptBraces "[{}\[\]]"
@@ -250,7 +250,7 @@ if version >= 508 || !exists("did_typeScript_syn_inits")
   HiLink typeScriptIdentifier Identifier
   HiLink typeScriptRepeat Repeat
   HiLink typeScriptStatement Statement
-  HiLink typeScriptFuncKeyword Type
+  HiLink typeScriptFuncKeyword Function
   HiLink typeScriptMessage Keyword
   HiLink typeScriptDeprecated Exception
   HiLink typeScriptError Error

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -57,8 +57,8 @@ syntax case match
 
 "" Syntax in the typeScript code"{{{
 syn match typeScriptSpecial "\\\d\d\d\|\\."
-syn region typeScriptStringD start=+"+ skip=+\\\\\|\\"+ end=+"\|$+	contains=typeScriptSpecial,@htmlPreproc
-syn region typeScriptStringS start=+'+ skip=+\\\\\|\\'+ end=+'\|$+	contains=typeScriptSpecial,@htmlPreproc
+syn region typeScriptStringD start=+"+ skip=+\\\\\|\\"+ end=+"\|$+  contains=typeScriptSpecial,@htmlPreproc
+syn region typeScriptStringS start=+'+ skip=+\\\\\|\\'+ end=+'\|$+  contains=typeScriptSpecial,@htmlPreproc
 
 syn match typeScriptSpecialCharacter "'\\.'"
 syn match typeScriptNumber "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
@@ -189,9 +189,9 @@ syntax keyword typeScriptFuncKeyword function
 "syntax match typeScriptFuncComma /,/ contained
 " syntax region typeScriptFuncBlock contained matchgroup=typeScriptFuncBlock start="{" end="}" contains=@typeScriptAll,typeScriptParensErrA,typeScriptParensErrB,typeScriptParen,typeScriptBracket,typeScriptBlock fold
 
-syn match	typeScriptBraces "[{}\[\]]"
-syn match	typeScriptParens "[()]"
-syn match	typeScriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
+syn match   typeScriptBraces "[{}\[\]]"
+syn match   typeScriptParens "[()]"
+syn match   typeScriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
 syn match typeScriptEndColons "[;,]"
 syn match typeScriptLogicSymbols "\(&&\)\|\(||\)"
 
@@ -280,28 +280,29 @@ if version >= 508 || !exists("did_typeScript_syn_inits")
   HiLink typeScriptHtmlElemFuncs PreProc
 
   HiLink typeScriptCssStyles Label
-" Ajax Highlighting
-HiLink typeScriptBrowserObjects Constant
 
-HiLink typeScriptDOMObjects Constant
-HiLink typeScriptDOMMethods Exception
-HiLink typeScriptDOMProperties Type
+  " Ajax Highlighting
+  HiLink typeScriptBrowserObjects Constant
 
-HiLink typeScriptAjaxObjects htmlH1
-HiLink typeScriptAjaxMethods Exception
-HiLink typeScriptAjaxProperties Type
+  HiLink typeScriptDOMObjects Constant
+  HiLink typeScriptDOMMethods Exception
+  HiLink typeScriptDOMProperties Type
 
-HiLink typeScriptFuncDef Title
-    HiLink typeScriptFuncArg Special
-    HiLink typeScriptFuncComma Operator
+  HiLink typeScriptAjaxObjects htmlH1
+  HiLink typeScriptAjaxMethods Exception
+  HiLink typeScriptAjaxProperties Type
 
-HiLink typeScriptHtmlEvents Special
-HiLink typeScriptHtmlElemProperties Type
+  HiLink typeScriptFuncDef Title
+  HiLink typeScriptFuncArg Special
+  HiLink typeScriptFuncComma Operator
 
-HiLink typeScriptEventListenerKeywords Keyword
+  HiLink typeScriptHtmlEvents Special
+  HiLink typeScriptHtmlElemProperties Type
 
-HiLink typeScriptNumber Number
-HiLink typeScriptPropietaryObjects Constant
+  HiLink typeScriptEventListenerKeywords Keyword
+
+  HiLink typeScriptNumber Number
+  HiLink typeScriptPropietaryObjects Constant
 
   delcommand HiLink
 endif


### PR DESCRIPTION
Hi,

I fixed a few issues I had with this plugin:

 * Syntax highlighting for function definitions was broken. Type annotations completly messed up the highlighting, the used colors were inconsistent with e.g. javascript function highlighting. I simplified it by removing (just commented out for now) the special `match` rules for functions and parameters and instead simply kept the `function` keyword. Should also fix #13.
 * Used `contained` on HTML element properties, ajax methods and others and used the `typeScriptDotNotation` rule for those. This used to mess up e.g. class method definitions with names like "load", "send" or "id". (Even though calling those methods will still trigger those highlighting rules – I'm not sure if they should be kept at all, but I could live with that.)
 * Changed some of the highlighting groups to be more consistent overall
 * Fixed indentation. `.ts` files by default are set to `filetype xml` in (stock) vim, which sets the `identexpr` variable, thus effectively preventing C indention for typescript files. (Might also be related to #23, but I never use tabs in my code so I can't reproduce this.)

And some other minor fixes.