### PR TITLE
Allow semicolon ommission on var declaration

### DIFF
--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -54,6 +54,12 @@ function GetTypescriptIndent()
         return indent(prev)
     endif
 
+    " If a variable was declared and the semicolon omitted, do not indent
+    " the next line
+    if getline(prev) =~ '^\s*var\s\+\w\+'
+        return indent(prev)
+    endif
+
     " Try to find out whether the last `}` ended a `<variable> : {` block
     if getline(prev) =~ '};\s*$'
         " jump to matching `{` bracket


### PR DESCRIPTION
The indentation function will not follow cindent practises if there is
a variable declared and the semicolon omitted on the previous line. The
indentation for the next line will be the same as the previous line.