### PR TITLE
Removing foldtext function as it overrides any provided in vimrc file…

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -202,9 +202,11 @@ syn match typescriptLogicSymbols "\(&&\)\|\(||\)"
 " typescriptFold Function {{{
 
 " function! typescriptFold()
-syn region foldBraces start=/{/ end=/}/ transparent fold keepend extend
 
-setl foldtext=FoldText()
+" skip curly braces inside RegEx's and comments
+syn region foldBraces start=/{/ skip=/\(\/\/.*\)\|\(\/.*\/\)/ end=/}/ transparent fold keepend extend
+
+" setl foldtext=FoldText()
 " endfunction
 
 " au FileType typescript call typescriptFold()


### PR DESCRIPTION
…. Updating the folding region so that it does not erroneously include curly braces inside regular expressions and code that is commented out