### PR TITLE
Fixed errorformat

### DIFF
--- a/compiler/typescript.vim
+++ b/compiler/typescript.vim
@@ -13,4 +13,4 @@ endif
 
 let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $*  %'
 
-CompilerSet errorformat=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m
+CompilerSet errorformat=%f(%l\\\,%c):\ error\ TS%n:\ %m


### PR DESCRIPTION
Currently, my `tsc` compiler outputs an error as below:

```
foo.ts(7,19): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
```

And quickfix reported the error as below.

```
foo.ts|7 col 19| foo.ts(7,19): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'string'.
```

It seemed that `errorformat` was broken and I fixed it.
After the fix, quickfix reports the error properly as below:

```
foo.ts|7 col 19 error 2345| Argument of type 'string[]' is not assignable to parameter of type 'string'.
```
- Environment
  - `message TS6029: Version 1.5.0-beta`
  - OS X 10.9.5
