### PR TITLE
Add a option to compile by tsconfig.json

### DIFF
--- a/compiler/typescript.vim
+++ b/compiler/typescript.vim
@@ -11,6 +11,10 @@ if !exists("g:typescript_compiler_options")
   let g:typescript_compiler_options = ""
 endif
 
-let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $*  %'
+if get(g:, 'typescript_compile_by_tsconfig')
+  let &l:makeprg = g:typescript_compiler_binary
+else
+  let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $*  %'
+endif
 
 CompilerSet errorformat=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m


### PR DESCRIPTION
"tsconfig.json" is supported from Typescript 1.5, so I added a option to compile by "tsconfig.json".
When the option "typescript_compile_by_tsconfig" is 1, invoke tsc with no option, that means tsc use "tsconfig.json".