### PR TITLE
Detect '.tsx' as TypeScript file

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript
+autocmd BufNewFile,BufRead *.ts,*.tsx setlocal filetype=typescript


### PR DESCRIPTION
TypeScript 1.6 will include JSX support and its file extension will be `.tsx`.
The `.tsx` file is basically TypeScript code which includes XML syntax of JSX and typescript-vim should detect it.

https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#new-tsx-file-extension-and-as-operator