### PR TITLE
Made current file as compiler target optional.

### DIFF
--- a/compiler/typescript.vim
+++ b/compiler/typescript.vim
@@ -11,6 +11,10 @@ if !exists("g:typescript_compiler_options")
   let g:typescript_compiler_options = ""
 endif
 
-let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $*  %'
+if !exists("g:typescript_compiler_target")
+  let g:typescript_compiler_target = '%'
+endif
+
+let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $* ' .  g:typescript_compiler_target
 
 CompilerSet errorformat=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m


### PR DESCRIPTION
I am really glad I discovered typescript-vim. However, in my current workflow there is one problem. I do compile-on-save in vim. When the compiler starts with the current file as target it does not take the 'tsconfig.json' into account. That configuration file is essential to be able to find definitions in other modules. So I added a switch 'g:typescript_compiler_target' that defaults to '%' (the current situation).
When it is set to '', the typescript compiler takes the 'tsconfig.json' into account.