### PR TITLE
Add feature for template strings

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -59,7 +59,8 @@ syntax case match
 syn match typescriptSpecial "\\\d\d\d\|\\."
 syn region typescriptStringD start=+"+ skip=+\\\\\|\\"+ end=+"\|$+  contains=typescriptSpecial,@htmlPreproc extend
 syn region typescriptStringS start=+'+ skip=+\\\\\|\\'+ end=+'\|$+  contains=typescriptSpecial,@htmlPreproc extend
-syn region typescriptStringB start=+`+ skip=+\\\\\|\\`+ end=+`+  contains=typescriptSpecial,@htmlPreproc extend
+syn region typescriptStringB start=+`+ skip=+\\\\\|\\`+ end=+`+  contains=typescriptStringSubstitution,typescriptSpecial,@htmlPreproc extend
+syn region typescriptStringSubstitution start=+\${+ end=+}+  contains=typescriptExpression extend
 
 syn match typescriptSpecialCharacter "'\\.'"
 syn match typescriptNumber "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
@@ -247,6 +248,7 @@ if version >= 508 || !exists("did_typescript_syn_inits")
   HiLink typescriptStringS String
   HiLink typescriptStringD String
   HiLink typescriptStringB String
+  HiLink typescriptStringSubstitution Statement
   HiLink typescriptRegexpString String
   HiLink typescriptGlobal Constant
   HiLink typescriptCharacter Character


### PR DESCRIPTION
ref #54 

Added support for emebd variables in [template strings literals](https://basarat.gitbooks.io/typescript/content/docs/template-strings.html).

### before

<img width="722" alt="2016-02-08 08 58 07" src="https://cloud.githubusercontent.com/assets/1239245/12876291/979a5378-ce42-11e5-8c84-56ad37937409.png">

### after

<img width="723" alt="2016-02-08 08 57 20" src="https://cloud.githubusercontent.com/assets/1239245/12876292/9c3e5424-ce42-11e5-8db4-e3f788eedf17.png">