### PR TITLE
Add ts extension to suffixes for gf

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -13,6 +13,8 @@ setlocal commentstring=//\ %s
 " " and insert the comment leader when hitting <CR> or using "o".
 setlocal formatoptions-=t formatoptions+=croql
 
+setlocal suffixesadd+=.ts
+
 let b:undo_ftplugin = "setl fo< ofu< com< cms<"
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
So you can 'gf' on an import to go to that file.

``` typescript
import foo from './foo';
```

Just like `gf`, if the cursor is under `'./foo'` it will now look for a `./foo.ts` file to go to.