### PR TITLE
Use setfiletype instead of setlocal filetype=

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.ts,*.tsx setlocal filetype=typescript
+autocmd BufNewFile,BufRead *.ts,*.tsx setfiletype typescript


### PR DESCRIPTION
Plugins should not use setlocal filetype= while it force to overwrite existing filetype.

```
 :setf[iletype] {filetype}			*:setf* *:setfiletype*
 			Set the 'filetype' option to {filetype}, but only if
 			not done yet in a sequence of (nested) autocommands.
 			This is short for: >
 				:if !did_filetype()
 				:  setlocal filetype={filetype}
 				:endif
 <			This command is used in a filetype.vim file to avoid
 			setting the 'filetype' option twice, causing different
 			settings and syntax files to be loaded.
 			{not in Vi}
```

See [:help setfiletype](http://vimdoc.sourceforge.net/htmldoc/options.html#:setfiletype)

This cause wrong filetype assignment for example when user tried to diff content (`ft=diff`) and reassign the filetype of the content.