### PR TITLE
fix Fixedgq: remove invalid semicolon

### DIFF
--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -440,7 +440,7 @@ let &cpo = s:cpo_save
 unlet s:cpo_save
 
 function! Fixedgq(lnum, count)
-    let l:tw = &tw ? &tw : 80;
+    let l:tw = &tw ? &tw : 80
 
     let l:count = a:count
     let l:first_char = indent(a:lnum) + 1


### PR DESCRIPTION
This semicolon must be a typo; Vim script does not allow the trailing semicolon like this.