### PR TITLE
2.0 new contextual keywords

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -112,7 +112,7 @@ syntax keyword typescriptDeprecated escape unescape all applets alinkColor bgCol
 syntax keyword typescriptConditional if else switch
 syntax keyword typescriptRepeat do while for in of
 syntax keyword typescriptBranch break continue yield await
-syntax keyword typescriptLabel case default async
+syntax keyword typescriptLabel case default async readonly
 syntax keyword typescriptStatement return with
 
 syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity Math Number NaN Object Packages RegExp String Symbol netscape

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -129,7 +129,7 @@ syntax keyword typescriptReserved constructor declare as interface module abstra
   syn match typescriptParameters "([a-zA-Z0-9_?.$][\w?.$]*)\s*:\s*([a-zA-Z0-9_?.$][\w?.$]*)" contained skipwhite
 "}}}
 " DOM2 Objects"{{{
-  syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol
+  syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol never
   syntax keyword typescriptExceptions DOMException
 "}}}
 " DOM2 CONSTANT"{{{


### PR DESCRIPTION
In [TypeScript 2.0](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#typescript-20), `readonly` and `never` were added as new contextual keywords.  I added them to highlight groups.