### PR TITLE
Remove unused highlight rule to fix that '\0' is not highlighted

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -65,7 +65,6 @@ syn region typescriptInterpolation matchgroup=typescriptInterpolationDelimiter
       \ start=/${/ end=/}/ contained
       \ contains=@typescriptExpression
 
-syn match typescriptSpecialCharacter "'\\.'"
 syn match typescriptNumber "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
 syn region typescriptRegexpString start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
 " syntax match typescriptSpecial "\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\."


### PR DESCRIPTION
### Before

![2016-07-17 21 07 37](https://cloud.githubusercontent.com/assets/823277/16900573/07cb059a-4c63-11e6-83b8-a5639e5e0c99.png)

### After

![2016-07-17 21 06 12](https://cloud.githubusercontent.com/assets/823277/16900576/0f5fe280-4c63-11e6-918a-a5acf5be2473.png)

-----

I had noticed that `'\0'` was not highlighted properly and I found unused `typescriptSpecialCharacter` prevented it from highlighting. (`typescriptSpecial` is now being used.)  I simply removed the unused highlight.