### PR TITLE
Support get and set keywords

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -123,7 +123,7 @@ syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity Math
 
 syntax keyword typescriptExceptions try catch throw finally Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 
-syntax keyword typescriptReserved constructor declare as interface module abstract enum int short export interface static byte extends long super char final native synchronized class float package throws const goto private transient debugger implements protected volatile double import public type namespace from
+syntax keyword typescriptReserved constructor declare as interface module abstract enum int short export interface static byte extends long super char final native synchronized class float package throws const goto private transient debugger implements protected volatile double import public type namespace from get set
 "}}}
 "" typescript/DOM/HTML/CSS specified things"{{{
 


### PR DESCRIPTION
I just put them in with the rest of the reserved words.

See: https://www.typescriptlang.org/docs/handbook/classes.html#accessors

Fixes #88.