### PR TITLE
Add "keyof" to reserved words

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -122,7 +122,7 @@ syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity Math
 
 syntax keyword typescriptExceptions try catch throw finally Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 
-syntax keyword typescriptReserved constructor declare as interface module abstract enum int short export interface static byte extends long super char final native synchronized class float package throws goto private transient debugger implements protected volatile double import public type namespace from get set
+syntax keyword typescriptReserved constructor declare as interface module abstract enum int short export interface static byte extends long super char final native synchronized class float package throws goto private transient debugger implements protected volatile double import public type namespace from get set keyof
 "}}}
 "" typescript/DOM/HTML/CSS specified things"{{{
 


### PR DESCRIPTION
In TypeScript 2.1.x,  a new reserved word `keyof` is available. 
( https://github.com/Microsoft/TypeScript/pull/11929 )