### PR TITLE
Add 'object' Typescript type

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -132,7 +132,7 @@ syntax keyword typescriptReserved constructor declare as interface module abstra
   syn match typescriptParameters "([a-zA-Z0-9_?.$][\w?.$]*)\s*:\s*([a-zA-Z0-9_?.$][\w?.$]*)" contained skipwhite
 "}}}
 " DOM2 Objects"{{{
-  syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol never
+  syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol never object
   syntax keyword typescriptExceptions DOMException
 "}}}
 " DOM2 CONSTANT"{{{


### PR DESCRIPTION
`object` Typescript type appeared in 2.2 version: http://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html.