### PR TITLE
Add back *.tsx file detection

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,1 +1,4 @@
-autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript
+" use `set filetype` to override default filetype=xml for *.ts files
+autocmd BufNewFile,BufRead *.ts  set filetype=typescript
+" use `setfiletype` to not override any other plugins like ianks/vim-tsx
+autocmd BufNewFile,BufRead *.tsx setfiletype typescript

--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.ts,*.tsx setlocal filetype=typescript
+autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript


### PR DESCRIPTION
In addition to the work in #111 this puts back the ftdetect for *.tsx but uses `setfiletype` to avoid overwriting the filetype set by any other plugins.