### PR TITLE
Support numeric separator (i.e. 123_456)

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -65,14 +65,14 @@ syn region typescriptInterpolation matchgroup=typescriptInterpolationDelimiter
       \ start=/${/ end=/}/ contained
       \ contains=@typescriptExpression
 
-syn match typescriptNumber "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
+syn match typescriptNumber "-\=\<\d[0-9_]*L\=\>\|0[xX][0-9a-fA-F][0-9a-fA-F_]*\>"
 syn region typescriptRegexpString start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
 " syntax match typescriptSpecial "\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\."
 " syntax region typescriptStringD start=+"+ skip=+\\\\\|\\$"+ end=+"+ contains=typescriptSpecial,@htmlPreproc
 " syntax region typescriptStringS start=+'+ skip=+\\\\\|\\$'+ end=+'+ contains=typescriptSpecial,@htmlPreproc
 " syntax region typescriptRegexpString start=+/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gim]\{,3}+ contains=typescriptSpecial,@htmlPreproc oneline
 " syntax match typescriptNumber /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
-syntax match typescriptFloat /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
+syntax match typescriptFloat /\<-\=\%(\d[0-9_]*\.\d[0-9_]*\|\d[0-9_]*\.\|\.\d[0-9]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
 " syntax match typescriptLabel /\(?\s*\)\@<!\<\w\+\(\s*:\)\@=/
 
 syn match typescriptDecorators /@\([_$a-zA-Z][_$a-zA-Z0-9]*\.\)*[_$a-zA-Z][_$a-zA-Z0-9]*\>/


### PR DESCRIPTION
ECMAScript numeric separator proposal is now on stage3

https://github.com/tc39/proposal-numeric-separator

and will come to TypeScript at version 2.7.

https://github.com/Microsoft/TypeScript/pull/20324

Example:

```typescript
const i = 123_456;
const x = 0x1fa_EF6;
const f = 123_456.0_456;
const f2 = 123_456.4_5e1_2;
```

I added syntax highlight support for this feature. I confirmed it works on my machine:

<img width="227" alt="2018-01-11 11 57 02" src="https://user-images.githubusercontent.com/823277/34806476-8c9abb26-f6c6-11e7-962d-79aae9547a4a.png">
