### PR TITLE
Binary and octal literals

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -65,7 +65,9 @@ syn region typescriptInterpolation matchgroup=typescriptInterpolationDelimiter
       \ start=/${/ end=/}/ contained
       \ contains=@typescriptExpression
 
-syn match typescriptNumber "-\=\<\d[0-9_]*L\=\>\|0[xX][0-9a-fA-F][0-9a-fA-F_]*\>"
+syn match typescriptNumber "-\=\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>" display
+syn match typescriptNumber "-\=\<0[bB][01][01_]*\>" display
+syn match typescriptNumber "-\=\<0[oO]\o[0-7_]*\>" display
 syn region typescriptRegexpString start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
 " syntax match typescriptSpecial "\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\."
 " syntax region typescriptStringD start=+"+ skip=+\\\\\|\\$"+ end=+"+ contains=typescriptSpecial,@htmlPreproc

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -65,14 +65,14 @@ syn region typescriptInterpolation matchgroup=typescriptInterpolationDelimiter
       \ start=/${/ end=/}/ contained
       \ contains=@typescriptExpression
 
-syn match typescriptNumber "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
+syn match typescriptNumber "-\=\<\d[0-9_]*L\=\>\|0[xX][0-9a-fA-F][0-9a-fA-F_]*\>"
 syn region typescriptRegexpString start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
 " syntax match typescriptSpecial "\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\."
 " syntax region typescriptStringD start=+"+ skip=+\\\\\|\\$"+ end=+"+ contains=typescriptSpecial,@htmlPreproc
 " syntax region typescriptStringS start=+'+ skip=+\\\\\|\\$'+ end=+'+ contains=typescriptSpecial,@htmlPreproc
 " syntax region typescriptRegexpString start=+/\(\*\|/\)\@!+ skip=+\\\\\|\\/+ end=+/[gim]\{,3}+ contains=typescriptSpecial,@htmlPreproc oneline
 " syntax match typescriptNumber /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
-syntax match typescriptFloat /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
+syntax match typescriptFloat /\<-\=\%(\d[0-9_]*\.\d[0-9_]*\|\d[0-9_]*\.\|\.\d[0-9]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
 " syntax match typescriptLabel /\(?\s*\)\@<!\<\w\+\(\s*:\)\@=/
 
 syn match typescriptDecorators /@\([_$a-zA-Z][_$a-zA-Z0-9]*\.\)*[_$a-zA-Z][_$a-zA-Z0-9]*\>/


### PR DESCRIPTION
TypeScript supports binary literal (`0b`) and octal literal (`0o`).

Rel: https://www.typescriptlang.org/docs/handbook/basic-types.html

```typescript
var b = 0b110101011001;
console.log(b);
b = 0o1234567;
console.log(b);
```

I added support for them.