### PR TITLE
Fix integer literal

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -65,6 +65,7 @@ syn region typescriptInterpolation matchgroup=typescriptInterpolationDelimiter
       \ start=/${/ end=/}/ contained
       \ contains=@typescriptExpression
 
+syn match typescriptNumber "-\=\<\d[0-9_]*L\=\>" display
 syn match typescriptNumber "-\=\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>" display
 syn match typescriptNumber "-\=\<0[bB][01][01_]*\>" display
 syn match typescriptNumber "-\=\<0[oO]\o[0-7_]*\>" display


### PR DESCRIPTION
I previously added support for octal and binary int literals at #130. However, I noticed that I had broken decimal integer literal at ba0d89cb4d90f004ea47e087064f8ed3fd242619.

So I fixed it in this PR.