### PR TITLE
Include `jsx` in filetype when extension is `tsx`

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,4 +1,4 @@
 " use `set filetype` to override default filetype=xml for *.ts files
 autocmd BufNewFile,BufRead *.ts  set filetype=typescript
 " use `setfiletype` to not override any other plugins like ianks/vim-tsx
-autocmd BufNewFile,BufRead *.tsx setfiletype typescript
+autocmd BufNewFile,BufRead *.tsx setfiletype typescript.jsx


### PR DESCRIPTION
Following the convention that the filetype for **.jsx** files is `javascript.jsx`, **.tsx** files should also include the `jsx` filetype.

This enables syntax highlighting for the JSX portion in **.tsx** files.