### PR TITLE
Highlight unknown as typescriptType

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -135,7 +135,7 @@ syntax keyword typescriptReserved constructor declare as interface module abstra
   syn match typescriptParameters "([a-zA-Z0-9_?.$][\w?.$]*)\s*:\s*([a-zA-Z0-9_?.$][\w?.$]*)" contained skipwhite
 "}}}
 " DOM2 Objects"{{{
-  syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol never object
+  syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol never object unknown
   syntax keyword typescriptExceptions DOMException
 "}}}
 " DOM2 CONSTANT"{{{


### PR DESCRIPTION
unknown type is added since TypeScript 3.
https://blogs.msdn.microsoft.com/typescript/2018/07/30/announcing-typescript-3-0/#the-unknown-type