### PR TITLE
Fix code points notation in string literals

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -56,7 +56,7 @@ endif "" JSDoc end
 syntax case match
 
 "" Syntax in the typescript code"{{{
-syn match typescriptSpecial "\\\d\d\d\|\\."
+syn match typescriptSpecial "\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}" contained containedin=typescriptStringD,typescriptStringS,typescriptStringB display
 syn region typescriptStringD start=+"+ skip=+\\\\\|\\"+ end=+"\|$+  contains=typescriptSpecial,@htmlPreproc extend
 syn region typescriptStringS start=+'+ skip=+\\\\\|\\'+ end=+'\|$+  contains=typescriptSpecial,@htmlPreproc extend
 syn region typescriptStringB start=+`+ skip=+\\\\\|\\`+ end=+`+  contains=typescriptInterpolation,typescriptSpecial,@htmlPreproc extend


### PR DESCRIPTION
Unicode codepoint notations like `\x00A5` or `\20` or `\x0a` are not highlighted in string literal. I fixed them in this PR as follows:

- Current

![2018-08-08 12 24 43](https://user-images.githubusercontent.com/823277/43814501-b33b2732-9b05-11e8-8c8d-8774103e50f8.png)

- By this PR

![2018-08-08 12 24 00](https://user-images.githubusercontent.com/823277/43814513-c22c13c8-9b05-11e8-9b39-18bfee9c0ec2.png)
