### PR TITLE
Fix place of screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ autocmd QuickFixCmdPost [^l]* nested cwindow
 autocmd QuickFixCmdPost    l* nested lwindow
 ```
 
+![Obligatory screenshot](https://raw.github.com/leafgarland/typescript-vim/master/vimshot01.png)
+
 Syntax highlighting
 -------------------
 
@@ -118,5 +120,3 @@ Syntax highlighting for TypeScript can be customized by following variables.
   highlighted.
 - `g:typescript_ignore_browserwords`: When this variable is set to `1`, browser API names such as
   `window` or `document` will not be highlighted. (default to `0`)
-
-![Obligatory screenshot](https://raw.github.com/leafgarland/typescript-vim/master/vimshot01.png)


### PR DESCRIPTION
I'm sorry that in previous PR I mistook the place of screenshot for quickfix. This PR fixes the mistake.