### PR TITLE
Fix indentation

### DIFF
--- a/indent/typescript.vim
+++ b/indent/typescript.vim
@@ -1,359 +1,475 @@
 " Vim indent file
-" Language: Typescript
-" Acknowledgement: Almost direct copy from https://github.com/pangloss/vim-javascript
+" Language: Javascript
+" Maintainer: Chris Paul ( https://github.com/bounceme )
+" URL: https://github.com/pangloss/vim-javascript
+" Last Change: December 4, 2017
 
 " Only load this indent file when no other was loaded.
-if exists('b:did_indent') || get(g:, 'typescript_indent_disable', 0)
+if exists('b:did_indent')
   finish
 endif
 let b:did_indent = 1
 
 " Now, set up our indentation expression and keys that trigger it.
-setlocal indentexpr=GetTypescriptIndent()
+setlocal indentexpr=GetJavascriptIndent()
 setlocal autoindent nolisp nosmartindent
 setlocal indentkeys+=0],0)
+" Testable with something like:
+" vim  -eNs "+filetype plugin indent on" "+syntax on" "+set ft=javascript" \
+"       "+norm! gg=G" '+%print' '+:q!' testfile.js \
+"       | diff -uBZ testfile.js -
 
 let b:undo_indent = 'setlocal indentexpr< smartindent< autoindent< indentkeys<'
 
 " Only define the function once.
-if exists('*GetTypescriptIndent')
+if exists('*GetJavascriptIndent')
   finish
 endif
 
 let s:cpo_save = &cpo
 set cpo&vim
 
+" indent correctly if inside <script>
+" vim/vim@690afe1 for the switch from cindent
+" overridden with b:html_indent_script1
+call extend(g:,{'html_indent_script1': 'inc'},'keep')
+
+" Regex of syntax group names that are or delimit string or are comments.
+let s:bvars = {
+      \ 'syng_strcom': 'string\|comment\|regex\|special\|doc\|template\%(braces\)\@!',
+      \ 'syng_str': 'string\|template\|special' }
+" template strings may want to be excluded when editing graphql:
+" au! Filetype javascript let b:syng_str = '^\%(.*template\)\@!.*string\|special'
+" au! Filetype javascript let b:syng_strcom = '^\%(.*template\)\@!.*string\|comment\|regex\|special\|doc'
+
+function s:GetVars()
+  call extend(b:,extend(s:bvars,{'js_cache': [0,0,0]}),'keep')
+endfunction
+
 " Get shiftwidth value
 if exists('*shiftwidth')
   function s:sw()
-	return shiftwidth()
+    return shiftwidth()
   endfunction
 else
   function s:sw()
-	return &sw
+    return &l:shiftwidth ? &l:shiftwidth : &l:tabstop
   endfunction
 endif
 
+" Performance for forwards search(): start search at pos rather than masking
+" matches before pos.
+let s:z = has('patch-7.4.984') ? 'z' : ''
+
+" Expression used to check whether we should skip a match with searchpair().
+let s:skip_expr = "s:SynAt(line('.'),col('.')) =~? b:syng_strcom"
+let s:in_comm = s:skip_expr[:-14] . "'comment\\|doc'"
+
+let s:rel = has('reltime')
 " searchpair() wrapper
-if has('reltime')
-  function s:GetPair(start,end,flags,skip,time,...)
-	return searchpair('\m'.a:start,'','\m'.a:end,a:flags,a:skip,max([prevnonblank(v:lnum) - 2000,0] + a:000),a:time)
+if s:rel
+  function s:GetPair(start,end,flags,skip)
+    return searchpair('\m'.a:start,'','\m'.a:end,a:flags,a:skip,s:l1,a:skip ==# 's:SkipFunc()' ? 2000 : 200)
   endfunction
 else
-  function s:GetPair(start,end,flags,skip,...)
-	return searchpair('\m'.a:start,'','\m'.a:end,a:flags,a:skip,max([prevnonblank(v:lnum) - 1000,get(a:000,1)]))
+  function s:GetPair(start,end,flags,skip)
+    return searchpair('\m'.a:start,'','\m'.a:end,a:flags,a:skip,s:l1)
   endfunction
 endif
 
-" Regex of syntax group names that are or delimit string or are comments.
-let s:syng_strcom = 'string\|comment\|regex\|special\|doc\|template\%(braces\)\@!'
-let s:syng_str = 'string\|template\|special'
-let s:syng_com = 'comment\|doc'
-" Expression used to check whether we should skip a match with searchpair().
-let s:skip_expr = "synIDattr(synID(line('.'),col('.'),0),'name') =~? '".s:syng_strcom."'"
-
-function s:skip_func()
-  if !s:free || search('\m`\|\${\|\*\/','nW',s:looksyn)
-	let s:free = !eval(s:skip_expr)
-	let s:looksyn = line('.')
-	return !s:free
+function s:SynAt(l,c)
+  let byte = line2byte(a:l) + a:c - 1
+  let pos = index(s:synid_cache[0], byte)
+  if pos == -1
+    let s:synid_cache[:] += [[byte], [synIDattr(synID(a:l, a:c, 0), 'name')]]
   endif
-  let s:looksyn = line('.')
-  return getline('.') =~ '\%<'.col('.').'c\/.\{-}\/\|\%>'.col('.').'c[''"]\|\\$' &&
-		\ eval(s:skip_expr)
+  return s:synid_cache[1][pos]
 endfunction
 
-function s:alternatePair(stop)
-  let pos = getpos('.')[1:2]
-  while search('\m[][(){}]','bW',a:stop)
-	if !s:skip_func()
-	  let idx = stridx('])}',s:looking_at())
-	  if idx + 1
-		if s:GetPair(['\[','(','{'][idx], '])}'[idx],'bW','s:skip_func()',2000,a:stop) <= 0
-		  break
-		endif
-	  else
-		return
-	  endif
-	endif
+function s:ParseCino(f)
+  let [s, n, divider] = [strridx(&cino, a:f)+1, '', 0]
+  while s && &cino[ s ] =~ '[^,]'
+    if &cino[ s ] == '.'
+      let divider = 1
+    elseif &cino[ s ] ==# 's'
+      if n !~ '\d'
+        return n . s:sw() + 0
+      endif
+      let n = str2nr(n) * s:sw()
+      break
+    else
+      let [n, divider] .= [&cino[ s ], 0]
+    endif
+    let s += 1
   endwhile
-  call call('cursor',pos)
+  return str2nr(n) / max([divider, 1])
 endfunction
 
-function s:save_pos(f,...)
-  let l:pos = getpos('.')[1:2]
-  let ret = call(a:f,a:000)
-  call call('cursor',l:pos)
-  return ret
+" Optimized {skip} expr, only callable from the search loop which
+" GetJavascriptIndent does to find the containing [[{(] (side-effects)
+function s:SkipFunc()
+  if s:top_col == 1
+    throw 'out of bounds'
+  elseif s:check_in
+    if eval(s:skip_expr)
+      return 1
+    endif
+    let s:check_in = 0
+  elseif getline('.') =~ '\%<'.col('.').'c\/.\{-}\/\|\%>'.col('.').'c[''"]\|\\$'
+    if eval(s:skip_expr)
+      return 1
+    endif
+  elseif search('\m`\|\${\|\*\/','nW'.s:z,s:looksyn)
+    if eval(s:skip_expr)
+      let s:check_in = 1
+      return 1
+    endif
+  else
+    let s:synid_cache[:] += [[line2byte('.') + col('.') - 1], ['']]
+  endif
+  let [s:looksyn, s:top_col] = getpos('.')[1:2]
 endfunction
 
-function s:syn_at(l,c)
-  return synIDattr(synID(a:l,a:c,0),'name')
+function s:AlternatePair()
+  let [pat, l:for] = ['[][(){};]', 2]
+  while s:SearchLoop(pat,'bW','s:SkipFunc()')
+    if s:LookingAt() == ';'
+      if !l:for
+        if s:GetPair('{','}','bW','s:SkipFunc()')
+          return
+        endif
+        break
+      else
+        let [pat, l:for] = ['[{}();]', l:for - 1]
+      endif
+    else
+      let idx = stridx('])}',s:LookingAt())
+      if idx == -1
+        return
+      elseif !s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:SkipFunc()')
+        break
+      endif
+    endif
+  endwhile
+  throw 'out of bounds'
 endfunction
 
-function s:looking_at()
+function s:Nat(int)
+  return a:int * (a:int > 0)
+endfunction
+
+function s:LookingAt()
   return getline('.')[col('.')-1]
 endfunction
 
-function s:token()
-  return s:looking_at() =~ '\k' ? expand('<cword>') : s:looking_at()
+function s:Token()
+  return s:LookingAt() =~ '\k' ? expand('<cword>') : s:LookingAt()
 endfunction
 
-function s:previous_token()
-  let l:n = line('.')
-  if (s:looking_at() !~ '\k' || search('\m\<','cbW')) && search('\m\S','bW')
-	if (getline('.')[col('.')-2:col('.')-1] == '*/' || line('.') != l:n &&
-		  \ getline('.') =~ '\%<'.col('.').'c\/\/') && s:syn_at(line('.'),col('.')) =~? s:syng_com
-	  while search('\m\/\ze[/*]','cbW')
-		if !search('\m\S','bW')
-		  break
-		elseif s:syn_at(line('.'),col('.')) !~? s:syng_com
-		  return s:token()
-		endif
-	  endwhile
-	else
-	  return s:token()
-	endif
+function s:PreviousToken(...)
+  let [l:pos, tok] = [getpos('.'), '']
+  if search('\m\k\{1,}\|\S','ebW')
+    if getline('.')[col('.')-2:col('.')-1] == '*/'
+      if eval(s:in_comm) && !s:SearchLoop('\S\ze\_s*\/[/*]','bW',s:in_comm)
+        call setpos('.',l:pos)
+      else
+        let tok = s:Token()
+      endif
+    else
+      let two = a:0 || line('.') != l:pos[1] ? strridx(getline('.')[:col('.')],'//') + 1 : 0
+      if two && eval(s:in_comm)
+        call cursor(0,two)
+        let tok = s:PreviousToken(1)
+        if tok is ''
+          call setpos('.',l:pos)
+        endif
+      else
+        let tok = s:Token()
+      endif
+    endif
   endif
-  return ''
+  return tok
 endfunction
 
-function s:others(p)
-  return "((line2byte(line('.')) + col('.')) <= ".(line2byte(a:p[0]) + a:p[1]).") || ".s:skip_expr
+function s:Pure(f,...)
+  return eval("[call(a:f,a:000),cursor(a:firstline,".col('.').")][0]")
 endfunction
 
-function s:tern_skip(p)
-  return s:GetPair('{','}','nbW',s:others(a:p),200,a:p[0]) > 0
+function s:SearchLoop(pat,flags,expr)
+  return s:GetPair(a:pat,'\_$.',a:flags,a:expr)
 endfunction
 
-function s:tern_col(p)
-  return s:GetPair('?',':\@<!::\@!','nbW',s:others(a:p)
-		\ .' || s:tern_skip('.string(a:p).')',200,a:p[0]) > 0
-endfunction
-
-function s:label_col()
-  let pos = getpos('.')[1:2]
-  let [s:looksyn,s:free] = pos
-  call s:alternatePair(0)
-  if s:save_pos('s:IsBlock')
-	let poss = getpos('.')[1:2]
-	return call('cursor',pos) || !s:tern_col(poss)
-  elseif s:looking_at() == ':'
-	return !s:tern_col([0,0])
+function s:ExprCol()
+  if getline('.')[col('.')-2] == ':'
+    return 1
   endif
-endfunction
-
-" configurable regexes that define continuation lines, not including (, {, or [.
-let s:opfirst = '^' . get(g:,'typescript_opfirst',
-	  \ '\%([<>=,?^%|*/&]\|\([-.:+]\)\1\@!\|!=\|in\%(stanceof\)\=\>\)')
-let s:continuation = get(g:,'typescript_continuation',
-	  \ '\%([-+<>=,.~!?/*^%|&:]\|\<\%(typeof\|delete\|void\|in\|instanceof\)\)') . '$'
-
-function s:continues(ln,con)
-  return !cursor(a:ln, match(' '.a:con,s:continuation)) &&
-		\ eval( (['s:syn_at(line("."),col(".")) !~? "regex"'] +
-		\ repeat(['getline(".")[col(".")-2] != tr(s:looking_at(),">","=")'],3) +
-		\ repeat(['s:previous_token() != "."'],5) + [1])[
-		\ index(split('/ > - + typeof in instanceof void delete'),s:token())])
-endfunction
-
-" get the line of code stripped of comments and move cursor to the last
-" non-comment char.
-function s:Trim(ln)
-  call cursor(a:ln+1,1)
-  call s:previous_token()
-  return strpart(getline('.'),0,col('.'))
-endfunction
-
-" Find line above 'lnum' that isn't empty or in a comment
-function s:PrevCodeLine(lnum)
-  let l:n = prevnonblank(a:lnum)
-  while l:n
-	if getline(l:n) =~ '^\s*\/[/*]' 
-	  if (stridx(getline(l:n),'`') > 0 || getline(l:n-1)[-1:] == '\') &&
-			\ s:syn_at(l:n,1) =~? s:syng_str
-		return l:n
-	  endif
-	  let l:n = prevnonblank(l:n-1)
-	elseif getline(l:n) =~ '\([/*]\)\1\@![/*]' && s:syn_at(l:n,1) =~? s:syng_com
-	  let l:n = s:save_pos('eval',
-			\ 'cursor('.l:n.',1) + search(''\m\/\*'',"bW")')
-	else
-	  return l:n
-	endif
+  let bal = 0
+  while s:SearchLoop('[{}?:]','bW',s:skip_expr)
+    if s:LookingAt() == ':'
+      let bal -= !search('\m:\%#','bW')
+    elseif s:LookingAt() == '?'
+      if getline('.')[col('.'):col('.')+1] =~ '^\.\d\@!'
+        " ?. conditional chain, not ternary start
+      elseif !bal
+        return 1
+      else
+        let bal += 1
+      endif
+    elseif s:LookingAt() == '{'
+      return !s:IsBlock()
+    elseif !s:GetPair('{','}','bW',s:skip_expr)
+      break
+    endif
   endwhile
 endfunction
 
+" configurable regexes that define continuation lines, not including (, {, or [.
+let s:opfirst = '^' . get(g:,'javascript_opfirst',
+      \ '\C\%([<>=,.?^%|/&]\|\([-:+]\)\1\@!\|\*\+\|!=\|in\%(stanceof\)\=\>\)')
+let s:continuation = get(g:,'javascript_continuation',
+      \ '\C\%([<=,.~!?/*^%|&:]\|+\@<!+\|-\@<!-\|=\@<!>\|\<\%(typeof\|new\|delete\|void\|in\|instanceof\|await\)\)') . '$'
+
+function s:Continues()
+  let tok = matchstr(strpart(getline('.'),col('.')-15,15),s:continuation)
+  if tok =~ '[a-z:]'
+    return tok == ':' ? s:ExprCol() : s:PreviousToken() != '.'
+  elseif tok !~ '[/>]'
+    return tok isnot ''
+  endif
+  return s:SynAt(line('.'),col('.')) !~? (tok == '>' ? 'jsflow\|^html' : 'regex')
+endfunction
+
 " Check if line 'lnum' has a balanced amount of parentheses.
-function s:Balanced(lnum)
+function s:Balanced(lnum,line)
   let l:open = 0
-  let l:line = getline(a:lnum)
-  let pos = match(l:line, '[][(){}]', 0)
+  let pos = match(a:line, '[][(){}]')
   while pos != -1
-	if s:syn_at(a:lnum,pos + 1) !~? s:syng_strcom
-	  let l:open += match(' ' . l:line[pos],'[[({]')
-	  if l:open < 0
-		return
-	  endif
-	endif
-	let pos = match(l:line, '[][(){}]', pos + 1)
+    if s:SynAt(a:lnum,pos + 1) !~? b:syng_strcom
+      let l:open += matchend(a:line[pos],'[[({]')
+      if l:open < 0
+        return
+      endif
+    endif
+    let pos = match(a:line, !l:open ? '[][(){}]' : '()' =~ a:line[pos] ?
+          \ '[()]' : '{}' =~ a:line[pos] ? '[{}]' : '[][]', pos + 1)
   endwhile
   return !l:open
 endfunction
 
-function s:OneScope(lnum)
-  let pline = s:Trim(a:lnum)
-  let kw = 'else do'
-  if pline[-1:] == ')' && s:GetPair('(', ')', 'bW', s:skip_expr, 100) > 0
-	call s:previous_token()
-	let kw = 'for if let while with'
-	if index(split('await each'),s:token()) + 1
-	  call s:previous_token()
-	  let kw = 'for'
-	endif
+function s:OneScope()
+  if s:LookingAt() == ')' && s:GetPair('(', ')', 'bW', s:skip_expr)
+    let tok = s:PreviousToken()
+    return (count(split('for if let while with'),tok) ||
+          \ tok =~# '^await$\|^each$' && s:PreviousToken() ==# 'for') &&
+          \ s:Pure('s:PreviousToken') != '.' && !(tok == 'while' && s:DoWhile())
+  elseif s:Token() =~# '^else$\|^do$'
+    return s:Pure('s:PreviousToken') != '.'
+  elseif strpart(getline('.'),col('.')-2,2) == '=>'
+    call cursor(0,col('.')-1)
+    return s:PreviousToken() != ')' || s:GetPair('(', ')', 'bW', s:skip_expr)
   endif
-  return pline[-2:] == '=>' || index(split(kw),s:token()) + 1 &&
-		\ s:save_pos('s:previous_token') != '.'
 endfunction
 
-" returns braceless levels started by 'i' and above lines * &sw. 'num' is the
-" lineNr which encloses the entire context, 'cont' if whether line 'i' + 1 is
-" a continued expression, which could have started in a braceless context
-function s:iscontOne(i,num,cont)
-  let [l:i, l:num, bL] = [a:i, a:num + !a:num, 0]
-  let pind = a:num ? indent(l:num) + s:W : 0
-  let ind = indent(l:i) + (a:cont ? 0 : s:W)
-  while l:i >= l:num && (ind > pind || l:i == l:num)
-	if indent(l:i) < ind && s:OneScope(l:i)
-	  let bL += s:W
-	  let l:i = line('.')
-	elseif !a:cont || bL || ind < indent(a:i)
-	  break
-	endif
-	let ind = min([ind, indent(l:i)])
-	let l:i = s:PrevCodeLine(l:i - 1)
+function s:DoWhile()
+  let cpos = searchpos('\m\<','cbW')
+  while s:SearchLoop('\C[{}]\|\<\%(do\|while\)\>','bW',s:skip_expr)
+    if s:LookingAt() =~ '\a'
+      if s:Pure('s:IsBlock')
+        if s:LookingAt() ==# 'd'
+          return 1
+        endif
+        break
+      endif
+    elseif s:LookingAt() != '}' || !s:GetPair('{','}','bW',s:skip_expr)
+      break
+    endif
   endwhile
-  return bL
+  call call('cursor',cpos)
+endfunction
+
+" returns total offset from braceless contexts. 'num' is the lineNr which
+" encloses the entire context, 'cont' if whether a:firstline is a continued
+" expression, which could have started in a braceless context
+function s:IsContOne(cont)
+  let [l:num, pind] = b:js_cache[1] ?
+        \ [b:js_cache[1], indent(b:js_cache[1]) + s:sw()] : [1,0]
+  let [ind, b_l] = [indent('.') + !a:cont, 0]
+  while line('.') > l:num && ind > pind || line('.') == l:num
+    if indent('.') < ind && s:OneScope()
+      let b_l += 1
+    elseif !a:cont || b_l || ind < indent(a:firstline)
+      break
+    else
+      call cursor(0,1)
+    endif
+    let ind = min([ind, indent('.')])
+    if s:PreviousToken() is ''
+      break
+    endif
+  endwhile
+  return b_l
+endfunction
+
+function s:IsSwitch()
+  return search(printf('\m\C\%%%dl\%%%dc%s',b:js_cache[1],b:js_cache[2],
+        \ '{\_s*\%(\%(\/\/.*\_$\|\/\*\_.\{-}\*\/\)\@>\_s*\)*\%(case\|default\)\>'),'nW'.s:z)
 endfunction
 
 " https://github.com/sweet-js/sweet.js/wiki/design#give-lookbehind-to-the-reader
 function s:IsBlock()
-  if s:looking_at() == '{'
-	let l:n = line('.')
-	let char = s:previous_token()
-	if match(s:stack,'xml\|jsx') + 1 && s:syn_at(line('.'),col('.')-1) =~? 'xml\|jsx'
-	  return char != '{'
-	elseif char =~ '\k'
-	  return index(split('return const let import export yield default delete var await void typeof throw case new in instanceof')
-			\ ,char) < (line('.') != l:n) || s:previous_token() == '.'
-	elseif char == '>'
-	  return getline('.')[col('.')-2] == '=' || s:syn_at(line('.'),col('.')) =~? '^jsflow'
-	elseif char == ':'
-	  return getline('.')[col('.')-2] != ':' && s:label_col()
-	elseif char == '/'
-	  return s:syn_at(line('.'),col('.')) =~? 'regex'
-	endif
-	return char !~ '[=~!<*,?^%|&([]' &&
-		  \ (char !~ '[-+]' || l:n != line('.') && getline('.')[col('.')-2] == char)
+  let tok = s:PreviousToken()
+  if join(s:stack) =~? 'xml\|jsx' && s:SynAt(line('.'),col('.')-1) =~? 'xml\|jsx'
+    let s:in_jsx = 1
+    return tok != '{'
+  elseif tok =~ '\k'
+    if tok ==# 'type'
+      return s:Pure('eval',"s:PreviousToken() !~# '^\\%(im\\|ex\\)port$' || s:PreviousToken() == '.'")
+    elseif tok ==# 'of'
+      return s:Pure('eval',"!s:GetPair('[[({]','[])}]','bW',s:skip_expr) || s:LookingAt() != '(' ||"
+            \ ."s:{s:PreviousToken() ==# 'await' ? 'Previous' : ''}Token() !=# 'for' || s:PreviousToken() == '.'")
+    endif
+    return index(split('return const let import export extends yield default delete var await void typeof throw case new in instanceof')
+          \ ,tok) < (line('.') != a:firstline) || s:Pure('s:PreviousToken') == '.'
+  elseif tok == '>'
+    return getline('.')[col('.')-2] == '=' || s:SynAt(line('.'),col('.')) =~? 'jsflow\|^html'
+  elseif tok == '*'
+    return s:Pure('s:PreviousToken') == ':'
+  elseif tok == ':'
+    return s:Pure('eval',"s:PreviousToken() =~ '^\\K\\k*$' && !s:ExprCol()")
+  elseif tok == '/'
+    return s:SynAt(line('.'),col('.')) =~? 'regex'
+  elseif tok !~ '[=~!<,.?^%|&([]'
+    return tok !~ '[-+]' || line('.') != a:firstline && getline('.')[col('.')-2] == tok
   endif
 endfunction
 
-function GetTypescriptIndent()
-  let b:js_cache = get(b:,'js_cache',[0,0,0])
-  " Get the current line.
-  call cursor(v:lnum,1)
-  let l:line = getline('.')
+function GetJavascriptIndent()
+  call s:GetVars()
+  let s:synid_cache = [[],[]]
+  let l:line = getline(v:lnum)
   " use synstack as it validates syn state and works in an empty line
-  let s:stack = synstack(v:lnum,1)
-  let syns = synIDattr(get(s:stack,-1),'name')
+  let s:stack = [''] + map(synstack(v:lnum,1),"synIDattr(v:val,'name')")
 
   " start with strings,comments,etc.
-  if syns =~? s:syng_com
-	if l:line =~ '^\s*\*'
-	  return cindent(v:lnum)
-	elseif l:line !~ '^\s*\/[/*]'
-	  return -1
-	endif
-  elseif syns =~? s:syng_str && l:line !~ '^[''"]'
-	if b:js_cache[0] == v:lnum - 1 && s:Balanced(v:lnum-1)
-	  let b:js_cache[0] = v:lnum
-	endif
-	return -1
-  endif
-  let l:lnum = s:PrevCodeLine(v:lnum - 1)
-  if !l:lnum
-	return
+  if s:stack[-1] =~? 'comment\|doc'
+    if l:line !~ '^\s*\/[/*]'
+      return l:line =~ '^\s*\*' ? cindent(v:lnum) : -1
+    endif
+  elseif s:stack[-1] =~? b:syng_str
+    if b:js_cache[0] == v:lnum - 1 && s:Balanced(v:lnum-1,getline(v:lnum-1))
+      let b:js_cache[0] = v:lnum
+    endif
+    return -1
   endif
 
+  let nest = get(get(b:,'hi_indent',{}),'blocklnr')
+  let s:l1 = max([0, prevnonblank(v:lnum) - (s:rel ? 2000 : 1000), nest])
+  call cursor(v:lnum,1)
+  if s:PreviousToken() is ''
+    return
+  endif
+  let [l:lnum, lcol, pline] = getpos('.')[1:2] + [getline('.')[:col('.')-1]]
+
   let l:line = substitute(l:line,'^\s*','','')
+  let l:line_s = l:line[0]
   if l:line[:1] == '/*'
-	let l:line = substitute(l:line,'^\%(\/\*.\{-}\*\/\s*\)*','','')
+    let l:line = substitute(l:line,'^\%(\/\*.\{-}\*\/\s*\)*','','')
   endif
   if l:line =~ '^\/[/*]'
-	let l:line = ''
+    let l:line = ''
   endif
 
   " the containing paren, bracket, or curly. Many hacks for performance
+  call cursor(v:lnum,1)
   let idx = index([']',')','}'],l:line[0])
-  if b:js_cache[0] >= l:lnum && b:js_cache[0] < v:lnum &&
-		\ (b:js_cache[0] > l:lnum || s:Balanced(l:lnum))
-	call call('cursor',b:js_cache[1:])
+  if b:js_cache[0] > l:lnum && b:js_cache[0] < v:lnum ||
+        \ b:js_cache[0] == l:lnum && s:Balanced(l:lnum,pline)
+    call call('cursor',b:js_cache[1:])
   else
-	let [s:looksyn, s:free, top] = [v:lnum - 1, 1, (!indent(l:lnum) &&
-		  \ s:syn_at(l:lnum,1) !~? s:syng_str) * l:lnum]
-	if idx + 1
-	  call s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:skip_func()',2000,top)
-	elseif getline(v:lnum) !~ '^\S' && syns =~? 'block'
-	  call s:GetPair('{','}','bW','s:skip_func()',2000,top)
-	else
-	  call s:alternatePair(top)
-	endif
+    let [s:looksyn, s:top_col, s:check_in, s:l1] = [v:lnum - 1,0,0,
+          \ max([s:l1, &smc ? search('\m^.\{'.&smc.',}','nbW',s:l1 + 1) + 1 : 0])]
+    try
+      if idx != -1
+        call s:GetPair(['\[','(','{'][idx],'])}'[idx],'bW','s:SkipFunc()')
+      elseif getline(v:lnum) !~ '^\S' && s:stack[-1] =~? 'block\|^jsobject$'
+        call s:GetPair('{','}','bW','s:SkipFunc()')
+      else
+        call s:AlternatePair()
+      endif
+    catch /^\Cout of bounds$/
+      call cursor(v:lnum,1)
+    endtry
+    let b:js_cache[1:] = line('.') == v:lnum ? [0,0] : getpos('.')[1:2]
   endif
 
-  let b:js_cache = [v:lnum] + (line('.') == v:lnum ? [0,0] : getpos('.')[1:2])
-  let num = b:js_cache[1]
+  let [b:js_cache[0], num] = [v:lnum, b:js_cache[1]]
 
-  let [s:W, isOp, bL, switch_offset] = [s:sw(),0,0,0]
-  if !num || s:IsBlock()
-	let ilnum = line('.')
-	let pline = s:save_pos('s:Trim',l:lnum)
-	if num && s:looking_at() == ')' && s:GetPair('(', ')', 'bW', s:skip_expr, 100) > 0
-	  let num = ilnum == num ? line('.') : num
-	  if idx < 0 && s:previous_token() ==# 'switch' && s:previous_token() != '.'
-		if &cino !~ ':'
-		  let switch_offset = s:W
-		else
-		  let cinc = matchlist(&cino,'.*:\zs\(-\)\=\(\d*\)\(\.\d\+\)\=\(s\)\=\C')
-		  let switch_offset = max([cinc[0] is '' ? 0 : (cinc[1].1) *
-				\ ((strlen(cinc[2].cinc[3]) ? str2nr(cinc[2].str2nr(cinc[3][1])) : 10) *
-				\ (cinc[4] is '' ? 1 : s:W)) / 10, -indent(num)])
-		endif
-		if pline[-1:] != '.' && l:line =~# '^\%(default\|case\)\>'
-		  return indent(num) + switch_offset
-		endif
-	  endif
-	endif
-	if idx < 0 && pline !~ '[{;]$'
-	  if pline =~# ':\@<!:$'
-		call cursor(l:lnum,strlen(pline))
-		let isOp = s:tern_col(b:js_cache[1:2]) * s:W
-	  else
-		let isOp = (l:line =~# s:opfirst || s:continues(l:lnum,pline)) * s:W
-	  endif
-	  let bL = s:iscontOne(l:lnum,b:js_cache[1],isOp)
-	  let bL -= (bL && l:line[0] == '{') * s:W
-	endif
+  let [num_ind, is_op, b_l, l:switch_offset, s:in_jsx] = [s:Nat(indent(num)),0,0,0,0]
+  if !num || s:LookingAt() == '{' && s:IsBlock()
+    let ilnum = line('.')
+    if num && !s:in_jsx && s:LookingAt() == ')' && s:GetPair('(',')','bW',s:skip_expr)
+      if ilnum == num
+        let [num, num_ind] = [line('.'), indent('.')]
+      endif
+      if idx == -1 && s:PreviousToken() ==# 'switch' && s:IsSwitch()
+        let l:switch_offset = &cino !~ ':' ? s:sw() : s:ParseCino(':')
+        if pline[-1:] != '.' && l:line =~# '^\%(default\|case\)\>'
+          return s:Nat(num_ind + l:switch_offset)
+        elseif &cino =~ '='
+          let l:case_offset = s:ParseCino('=')
+        endif
+      endif
+    endif
+    if idx == -1 && pline[-1:] !~ '[{;]'
+      call cursor(l:lnum, lcol)
+      let sol = matchstr(l:line,s:opfirst)
+      if sol is '' || sol == '/' && s:SynAt(v:lnum,
+            \ 1 + len(getline(v:lnum)) - len(l:line)) =~? 'regex'
+        if s:Continues()
+          let is_op = s:sw()
+        endif
+      elseif num && sol =~# '^\%(in\%(stanceof\)\=\|\*\)$' &&
+            \ s:LookingAt() == '}' && s:GetPair('{','}','bW',s:skip_expr) &&
+            \ s:PreviousToken() == ')' && s:GetPair('(',')','bW',s:skip_expr) &&
+            \ (s:PreviousToken() == ']' || s:LookingAt() =~ '\k' &&
+            \ s:{s:PreviousToken() == '*' ? 'Previous' : ''}Token() !=# 'function')
+        return num_ind + s:sw()
+      else
+        let is_op = s:sw()
+      endif
+      call cursor(l:lnum, lcol)
+      let b_l = s:Nat(s:IsContOne(is_op) - (!is_op && l:line =~ '^{')) * s:sw()
+    endif
+  elseif idx == -1 && s:LookingAt() == '(' && &cino =~ '(' &&
+        \ (search('\m\S','nbW',num) || s:ParseCino('U'))
+    let pval = s:ParseCino('(')
+    if !pval
+      let [Wval, vcol] = [s:ParseCino('W'), virtcol('.')]
+      if search('\m'.get(g:,'javascript_indent_W_pat','\S'),'W',num)
+        return s:ParseCino('w') ? vcol : virtcol('.')-1
+      endif
+      return Wval ? s:Nat(num_ind + Wval) : vcol
+    endif
+    return s:Nat(num_ind + pval + searchpair('\m(','','\m)','nbrmW',s:skip_expr,num) * s:sw())
   endif
 
   " main return
-  if idx + 1 || l:line[:1] == '|}'
-	return indent(num)
+  if l:line =~ '^[])}]\|^|}'
+    if l:line_s == ')'
+      if s:ParseCino('M')
+        return indent(l:lnum)
+      elseif num && &cino =~# 'm' && !s:ParseCino('m')
+        return virtcol('.') - 1
+      endif
+    endif
+    return num_ind
   elseif num
-	return indent(num) + s:W + switch_offset + bL + isOp
+    return s:Nat(num_ind + get(l:,'case_offset',s:sw()) + l:switch_offset + b_l + is_op)
+  elseif nest
+    return indent(nextnonblank(nest+1)) + b_l + is_op
   endif
-  return bL + isOp
+  return b_l + is_op
 endfunction
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-


### PR DESCRIPTION
There are 3 commits (right now) in this review. The first two updated to the latest indent file from 'pangloss/vim-javascript', and the third switched gears to `HerringtonDarkholme/yats.vim`. There are a few open issues with "indent" in their name:

- #93 is already fixed and should be closed.
- #118 is already fixed and should be closed. (`HerringtonDarkholme/yats.vim` does the wrong thing in this case, which would be a regression if we adopted their indent file.)
- #127 is a bug in all three projects.
- #133 reports two indentation bugs:
-- Comma-terminated member declarations within interface declarations. This is also a bug in `pangloss/vim-javascript`, but not in `HerringtonDarkholme/yats.vim`.
-- Enum declarations. This is a bug in all three projects.
- #138 is a bug in this project and 'pangloss/vim-javascript', but not in `HerringtonDarkholme/yats.vim`, which has a separate `tsx.vim` indent file.

I think TypeScript might be at the point that it deserves its own indent file, however, not one copied from JavaScript or Ruby. No one else is doing it, but I think this project, as the one chosen by `sheerun/vim-polyglot` for TypeScript, is the perfect candidate.