### PR TITLE
Adding ! as logical operator

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -206,7 +206,7 @@ syn match typescriptBraces "[{}\[\]]"
 syn match typescriptParens "[()]"
 syn match typescriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
 syn match typescriptEndColons "[;,]"
-syn match typescriptLogicSymbols "\(&&\)\|\(||\)"
+syn match typescriptLogicSymbols "\(&&\)\|\(||\)\|\(!\)"
 
 " typescriptFold Function {{{
 


### PR DESCRIPTION
It was missing from the `typescriptLogicSymbols` class, where I
think it belongs.

@leafgarland could you take a look please :eyes: ?