### PR TITLE
Adding JSON as global object.

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -124,7 +124,7 @@ syntax keyword typescriptBranch break continue yield await
 syntax keyword typescriptLabel case default async readonly
 syntax keyword typescriptStatement return with
 
-syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity Math Number NaN Object Packages RegExp String Symbol netscape
+syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity JSON Math Number NaN Object Packages RegExp String Symbol netscape
 
 syntax keyword typescriptExceptions try catch throw finally Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 


### PR DESCRIPTION
`JSON` was missing from `typescriptGlobalObjects`.
@leafgarland can you take a look at this one too please :eyeglasses: ?