### PR TITLE
Highlight unique symbol type

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -139,6 +139,7 @@ syntax keyword typescriptReserved constructor declare as interface module abstra
 "}}}
 " DOM2 Objects"{{{
   syntax keyword typescriptType DOMImplementation DocumentFragment Node NodeList NamedNodeMap CharacterData Attr Element Text Comment CDATASection DocumentType Notation Entity EntityReference ProcessingInstruction void any string boolean number symbol never object unknown
+  syntax match typescriptType /\<unique\s\+symbol\>/
   syntax keyword typescriptExceptions DOMException
 "}}}
 " DOM2 CONSTANT"{{{


### PR DESCRIPTION
`unique symbol` type was added to TypeScript at v2.7. This PR adds highlight for it.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#unique-symbol

```typescript
// Works
declare const Foo: unique symbol;

// Error! 'Bar' isn't a constant.
let Bar: unique symbol = Symbol();

// Works - refers to a unique symbol, but its identity is tied to 'Foo'.
let Baz: typeof Foo = Foo;

// Also works.
class C {
    static readonly StaticSymbol: unique symbol = Symbol();
}
```