### PR TITLE
Handle new `typescriptreact` filetype

### DIFF
--- a/syntax/typescriptreact.vim
+++ b/syntax/typescriptreact.vim
@@ -1,0 +1,1 @@
+typescript.vim


### PR DESCRIPTION
As of vim v8.1.1930 (and nvim v0.4.0), *.tsx files get a default filetype of `typescriptreact`.

I propose adding a symlink `typescriptreact.vim` to `typescript.vim` so that files with filetype `typescriptreact` will be highlighted the same as those with filetype `typescript`.

See:
- https://github.com/neovim/neovim/pull/10858
- https://github.com/vim/vim/commit/92852cee3fcff1dc6ce12387b234634e73267b22
- https://github.com/vim/vim/issues/4830