### PR TITLE
Compatibility with latest vim

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -223,10 +223,11 @@ syn region foldBraces start=/{/ skip=/\(\/\/.*\)\|\(\/.*\/\)/ end=/}/ transparen
 " }}}
 
 " Define the default highlighting.
-" For version 5.7 and earlier: only when not done already
+" For version 5.7 and earlier: only when not done already by this script
 " For version 5.8 and later: only when an item doesn't have highlighting yet
+" For version 8.1.1486 and later: only when not done already by this script (need to override vim's new typescript support)
 if version >= 508 || !exists("did_typescript_syn_inits")
-  if version < 508
+  if version < 508 || has('patch-8.1.1486')
     let did_typescript_syn_inits = 1
     command -nargs=+ HiLink hi link <args>
   else


### PR DESCRIPTION
I noticed some syntax highlighting issues with recent versions of vim:

![Screenshot from 2019-12-15 14-09-26](https://user-images.githubusercontent.com/2660313/70867554-a2ee8800-1f44-11ea-99a6-893795bb5071.png)

Normal keywords like `import` and `from` are now highlighted red. 

For reference, here are links to the relevant lines in [`$VIMRUNTIME/syntax/typescriptcommon.vim`](https://github.com/vim/vim/blob/559b9c68fe550f3af63d42e0838622aab1ceb1b3/runtime/syntax/typescriptcommon.vim#L1950) and [`[typescript-vim]/syntax/typescript.vim`](https://github.com/leafgarland/typescript-vim/blob/5a319ea5504e18215d155576c78d1b7fb8e22c8f/syntax/typescript.vim#L278)

Running `:hi typescriptReserved` reports `typescriptReserved xxx links to Error`. 

Vim has recently added built-in support for typescript. Vim's built-in syntax script is linking `typescriptReserved` to `Error`. This prevents typescript-vim from linking it to Keyword because typescript-vim uses the `def`/`default` option, essentially running: `:hi typescriptReserved def link Keyword`, which does nothing if `typescriptReserved` is already linked (i.e. by vim's builtin syntax support).

I don't know why this plugin chose to use `hi def link` instead of `hi link` in the first place. I also haven't verified the exact patch where vim added native typescript support. 