### PR TITLE
Fix typescript func keyword

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -87,22 +87,22 @@ syntax keyword typescriptPrototype contained prototype
 """"""""""""""""""""""""
 if get(g:, 'typescript_ignore_browserwords', 0)
   syntax keyword typescriptBrowserObjects window navigator screen history location
-  
+
   syntax keyword typescriptDOMObjects document event HTMLElement Anchor Area Base Body Button Form Frame Frameset Image Link Meta Option Select Style Table TableCell TableRow Textarea
   syntax keyword typescriptDOMMethods contained createTextNode createElement insertBefore replaceChild removeChild appendChild hasChildNodes cloneNode normalize isSupported hasAttributes getAttribute setAttribute removeAttribute getAttributeNode setAttributeNode removeAttributeNode getElementsByTagName hasAttribute getElementById adoptNode close compareDocumentPosition createAttribute createCDATASection createComment createDocumentFragment createElementNS createEvent createExpression createNSResolver createProcessingInstruction createRange createTreeWalker elementFromPoint evaluate getBoxObjectFor getElementsByClassName getSelection getUserData hasFocus importNode
   syntax keyword typescriptDOMProperties contained nodeName nodeValue nodeType parentNode childNodes firstChild lastChild previousSibling nextSibling attributes ownerDocument namespaceURI prefix localName tagName
-  
+
   syntax keyword typescriptAjaxObjects XMLHttpRequest
   syntax keyword typescriptAjaxProperties contained readyState responseText responseXML statusText
   syntax keyword typescriptAjaxMethods contained onreadystatechange abort getAllResponseHeaders getResponseHeader open send setRequestHeader
-  
+
   syntax keyword typescriptPropietaryObjects ActiveXObject
   syntax keyword typescriptPropietaryMethods contained attachEvent detachEvent cancelBubble returnValue
-  
+
   syntax keyword typescriptHtmlElemProperties contained className clientHeight clientLeft clientTop clientWidth dir href id innerHTML lang length offsetHeight offsetLeft offsetParent offsetTop offsetWidth scrollHeight scrollLeft scrollTop scrollWidth style tabIndex target title
-  
+
   syntax keyword typescriptEventListenerKeywords contained blur click focus mouseover mouseout load item
-  
+
   syntax keyword typescriptEventListenerMethods contained scrollIntoView addEventListener dispatchEvent removeEventListener preventDefault stopPropagation
 endif
 " }}}

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -267,7 +267,7 @@ if version >= 508 || !exists("did_typescript_syn_inits")
   HiLink typescriptStorageClass StorageClass
   HiLink typescriptRepeat Repeat
   HiLink typescriptStatement Statement
-  HiLink typescriptFuncKeyword Function
+  HiLink typescriptFuncKeyword Keyword
   HiLink typescriptMessage Keyword
   HiLink typescriptDeprecated Exception
   HiLink typescriptError Error


### PR DESCRIPTION
The "function" keyword is not, itself, a Function. It is a Keyword. This pull request solves the problem once and for all.

It also cleans up some unnecessary trailing whitespace in the first commit.