### PR TITLE
exclamation character wrong group

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -204,9 +204,9 @@ syntax keyword typescriptFuncKeyword function
 
 syn match typescriptBraces "[{}\[\]]"
 syn match typescriptParens "[()]"
-syn match typescriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
 syn match typescriptEndColons "[;,]"
 syn match typescriptLogicSymbols "\(&&\)\|\(||\)\|\(!\)"
+syn match typescriptOpSymbols "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\|-="
 
 " typescriptFold Function {{{
 


### PR DESCRIPTION
The exclamation character is considered as a `typescriptLogicSymbols` when in a `!==`, which breaks some fonts due to the color change.

With this line exchange, the exclamation is interpreted as it should be (`typescriptOpSymbols`)

*Before the change:*
![image](https://user-images.githubusercontent.com/22566633/75873263-e48a2300-5e0f-11ea-99dc-53c1284d35d6.png)

*After the change:*
![image](https://user-images.githubusercontent.com/22566633/75873277-efdd4e80-5e0f-11ea-92b0-69e126edd96a.png)

