### PR TITLE
Extend global objects definition with js and node keywords

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -124,7 +124,8 @@ syntax keyword typescriptBranch break continue yield await
 syntax keyword typescriptLabel case default async readonly
 syntax keyword typescriptStatement return with
 
-syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity JSON Math Number NaN Object Packages RegExp String Symbol netscape
+syntax keyword typescriptGlobalObjects Array Boolean Date Function Infinity JSON Math Number NaN Object Packages RegExp String Symbol netscape ArrayBuffer BigInt64Array BigUint64Array Float32Array Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array Uint8Array Uint8ClampedArray Buffer Collator DataView DateTimeFormat Intl Iterator Map Set WeakMap WeakSet NumberFormat ParallelArray Promise Proxy Reflect Uint8ClampedArray WebAssembly console document fetch window
+syntax keyword typescriptGlobalNodeObjects  module exports global process __dirname __filename
 
 syntax keyword typescriptExceptions try catch throw finally Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 
@@ -188,7 +189,7 @@ syntax match typescriptDotNotation "\.style\." nextgroup=typescriptCssStyles
 
 
 "" Code blocks
-syntax cluster typescriptAll contains=typescriptComment,typescriptLineComment,typescriptDocComment,typescriptStringD,typescriptStringS,typescriptStringB,typescriptRegexpString,typescriptNumber,typescriptFloat,typescriptDecorators,typescriptLabel,typescriptSource,typescriptType,typescriptOperator,typescriptBoolean,typescriptNull,typescriptFuncKeyword,typescriptConditional,typescriptGlobal,typescriptRepeat,typescriptBranch,typescriptStatement,typescriptGlobalObjects,typescriptMessage,typescriptIdentifier,typescriptStorageClass,typescriptExceptions,typescriptReserved,typescriptDeprecated,typescriptDomErrNo,typescriptDomNodeConsts,typescriptHtmlEvents,typescriptDotNotation,typescriptBrowserObjects,typescriptDOMObjects,typescriptAjaxObjects,typescriptPropietaryObjects,typescriptDOMMethods,typescriptHtmlElemProperties,typescriptDOMProperties,typescriptEventListenerKeywords,typescriptEventListenerMethods,typescriptAjaxProperties,typescriptAjaxMethods,typescriptFuncArg
+syntax cluster typescriptAll contains=typescriptComment,typescriptLineComment,typescriptDocComment,typescriptStringD,typescriptStringS,typescriptStringB,typescriptRegexpString,typescriptNumber,typescriptFloat,typescriptDecorators,typescriptLabel,typescriptSource,typescriptType,typescriptOperator,typescriptBoolean,typescriptNull,typescriptFuncKeyword,typescriptConditional,typescriptGlobal,typescriptRepeat,typescriptBranch,typescriptStatement,typescriptGlobalObjects,typescriptMessage,typescriptIdentifier,typescriptStorageClass,typescriptExceptions,typescriptReserved,typescriptDeprecated,typescriptDomErrNo,typescriptDomNodeConsts,typescriptHtmlEvents,typescriptDotNotation,typescriptBrowserObjects,typescriptDOMObjects,typescriptAjaxObjects,typescriptPropietaryObjects,typescriptDOMMethods,typescriptHtmlElemProperties,typescriptDOMProperties,typescriptEventListenerKeywords,typescriptEventListenerMethods,typescriptAjaxProperties,typescriptAjaxMethods,typescriptFuncArg,typescriptGlobalNodeObjects
 
 if main_syntax == "typescript"
   syntax sync clear
@@ -288,6 +289,7 @@ if version >= 508 || !exists("did_typescript_syn_inits")
   HiLink typescriptSpecial Special
   HiLink typescriptSource Special
   HiLink typescriptGlobalObjects Special
+  HiLink typescriptGlobalNodeObjects Special
   HiLink typescriptExceptions Special
 
   HiLink typescriptDomErrNo Constant


### PR DESCRIPTION
# 💎 What
This change adds known _javascript_ and _Node JS_ keywords and objects to the keyword list.

# 🦖 How
- Extend definition `typescriptGlobalObjects` with keywords (including `Map`, `Promise`, `console`, `document`, `fetch`, and  `window`, among others).
- Add new definition `typescriptGlobalNodeObjects` with keywords specific to Node JS.
- Update the `typescriptAll` cluster to include the new `typescriptGlobalNodeObjects` definition.
- Link the new `typescriptGlobalNodeObjects` definition to the `Special` highlight group.

# 🚀 Who
Hi 👋 My name is Patrick. First time contributor, happy to answer questions, let me know if you have feedback. Thanks!

# 🚒 GIF
![](https://media.giphy.com/media/l2JdUhw8mMsaQxaAE/giphy.gif)