### PR TITLE
add toggle to disable compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,7 @@ Syntax highlighting for TypeScript can be customized by following variables.
   highlighted.
 - `g:typescript_ignore_browserwords`: When this variable is set to `1`, browser API names such as
   `window` or `document` will not be highlighted. (default to `0`)
+- `g:typescript_disable_compiler`: When this variable is set to `1`, the compiler will not be modified
+  (default to `0`)
 
 ![Obligatory screenshot](https://raw.github.com/leafgarland/typescript-vim/master/vimshot01.png)

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -6,7 +6,9 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo-=C
 
-compiler typescript
+if !get(g:, 'typescript_disable_compiler', 0)
+	compiler typescript
+endif
 setlocal commentstring=//\ %s
 
 " Set 'formatoptions' to break comment lines but not other lines,


### PR DESCRIPTION
I tried setting makeprg but the plugin would overwrite it. I think you can create a compiler and set it using current_compiler but this seems like an easier way to do it