### PR TITLE
Removed all non-existence keywords

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -129,7 +129,7 @@ syntax keyword typescriptGlobalNodeObjects  module exports global process __dirn
 
 syntax keyword typescriptExceptions try catch throw finally Error EvalError RangeError ReferenceError SyntaxError TypeError URIError
 
-syntax keyword typescriptReserved constructor declare as interface module abstract enum int short export interface static byte extends long super char final native synchronized class float package throws goto private transient debugger implements protected volatile double import public type namespace from get set keyof
+syntax keyword typescriptReserved constructor declare as interface module abstract enum export interface static extends long super final native class throws private transient debugger implements protected volatile import public type namespace from get set keyof
 "}}}
 "" typescript/DOM/HTML/CSS specified things"{{{
 


### PR DESCRIPTION
After TypeScript 2.0, there're a lot of changes were implemented. Therefore some keyword like goto no longer available in ts. According to ECMAScript 2020 standard, this keywords aren't available in js as well. For `int` or `float`, they're not data types, there's only one type is `number` which accepts integer & float both. To get true integer, there's BigInt available.

http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ecmascript-language-types-number-type