### PR TITLE
fix: prefer default links except on ancient Vim versions

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -224,109 +224,103 @@ syn region foldBraces start=/{/ skip=/\(\/\/.*\)\|\(\/.*\/\)/ end=/}/ transparen
 " }}}
 
 " Define the default highlighting.
-" For version 5.7 and earlier: only when not done already by this script
-" For version 5.8 and later: only when an item doesn't have highlighting yet
-" For version 8.1.1486 and later, and nvim 0.5.0 and later: only when not done already by this script (need to override vim's new typescript support)
-if version >= 508 || !exists("did_typescript_syn_inits")
-  if version < 508 || has('patch-8.1.1486') || has('nvim-0.5.0')
-    let did_typescript_syn_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
-
-  "typescript highlighting
-  HiLink typescriptParameters Operator
-  HiLink typescriptSuperBlock Operator
-
-  HiLink typescriptEndColons Exception
-  HiLink typescriptOpSymbols Operator
-  HiLink typescriptLogicSymbols Boolean
-  HiLink typescriptBraces Function
-  HiLink typescriptParens Operator
-  HiLink typescriptComment Comment
-  HiLink typescriptLineComment Comment
-  HiLink typescriptRefComment Include
-  HiLink typescriptRefS String
-  HiLink typescriptRefD String
-  HiLink typescriptDocComment Comment
-  HiLink typescriptCommentTodo Todo
-  HiLink typescriptCvsTag Function
-  HiLink typescriptDocTags Special
-  HiLink typescriptDocSeeTag Function
-  HiLink typescriptDocParam Function
-  HiLink typescriptStringS String
-  HiLink typescriptStringD String
-  HiLink typescriptStringB String
-  HiLink typescriptInterpolationDelimiter Delimiter
-  HiLink typescriptRegexpString String
-  HiLink typescriptGlobal Constant
-  HiLink typescriptCharacter Character
-  HiLink typescriptPrototype Type
-  HiLink typescriptConditional Conditional
-  HiLink typescriptBranch Conditional
-  HiLink typescriptIdentifier Identifier
-  HiLink typescriptStorageClass StorageClass
-  HiLink typescriptRepeat Repeat
-  HiLink typescriptStatement Statement
-  HiLink typescriptFuncKeyword Keyword
-  HiLink typescriptMessage Keyword
-  HiLink typescriptDeprecated Exception
-  HiLink typescriptError Error
-  HiLink typescriptParensError Error
-  HiLink typescriptParensErrA Error
-  HiLink typescriptParensErrB Error
-  HiLink typescriptParensErrC Error
-  HiLink typescriptReserved Keyword
-  HiLink typescriptOperator Operator
-  HiLink typescriptType Type
-  HiLink typescriptNull Type
-  HiLink typescriptNumber Number
-  HiLink typescriptFloat Number
-  HiLink typescriptDecorators Special
-  HiLink typescriptBoolean Boolean
-  HiLink typescriptLabel Label
-  HiLink typescriptSpecial Special
-  HiLink typescriptSource Special
-  HiLink typescriptGlobalObjects Special
-  HiLink typescriptGlobalNodeObjects Special
-  HiLink typescriptExceptions Special
-
-  HiLink typescriptDomErrNo Constant
-  HiLink typescriptDomNodeConsts Constant
-  HiLink typescriptDomElemAttrs Label
-  HiLink typescriptDomElemFuncs PreProc
-
-  HiLink typescriptHtmlElemAttrs Label
-  HiLink typescriptHtmlElemFuncs PreProc
-
-  HiLink typescriptCssStyles Label
-
-  " Ajax Highlighting
-  HiLink typescriptBrowserObjects Constant
-
-  HiLink typescriptDOMObjects Constant
-  HiLink typescriptDOMMethods Function
-  HiLink typescriptDOMProperties Special
-
-  HiLink typescriptAjaxObjects Constant
-  HiLink typescriptAjaxMethods Function
-  HiLink typescriptAjaxProperties Special
-
-  HiLink typescriptFuncDef Title
-  HiLink typescriptFuncArg Special
-  HiLink typescriptFuncComma Operator
-
-  HiLink typescriptHtmlEvents Special
-  HiLink typescriptHtmlElemProperties Special
-
-  HiLink typescriptEventListenerKeywords Keyword
-
-  HiLink typescriptNumber Number
-  HiLink typescriptPropietaryObjects Constant
-
-  delcommand HiLink
+if version < 508
+  command -nargs=+ HiLink hi link <args>
+else
+  command -nargs=+ HiLink hi def link <args>
 endif
+
+"typescript highlighting
+HiLink typescriptParameters Operator
+HiLink typescriptSuperBlock Operator
+
+HiLink typescriptEndColons Exception
+HiLink typescriptOpSymbols Operator
+HiLink typescriptLogicSymbols Boolean
+HiLink typescriptBraces Function
+HiLink typescriptParens Operator
+HiLink typescriptComment Comment
+HiLink typescriptLineComment Comment
+HiLink typescriptRefComment Include
+HiLink typescriptRefS String
+HiLink typescriptRefD String
+HiLink typescriptDocComment Comment
+HiLink typescriptCommentTodo Todo
+HiLink typescriptCvsTag Function
+HiLink typescriptDocTags Special
+HiLink typescriptDocSeeTag Function
+HiLink typescriptDocParam Function
+HiLink typescriptStringS String
+HiLink typescriptStringD String
+HiLink typescriptStringB String
+HiLink typescriptInterpolationDelimiter Delimiter
+HiLink typescriptRegexpString String
+HiLink typescriptGlobal Constant
+HiLink typescriptCharacter Character
+HiLink typescriptPrototype Type
+HiLink typescriptConditional Conditional
+HiLink typescriptBranch Conditional
+HiLink typescriptIdentifier Identifier
+HiLink typescriptStorageClass StorageClass
+HiLink typescriptRepeat Repeat
+HiLink typescriptStatement Statement
+HiLink typescriptFuncKeyword Keyword
+HiLink typescriptMessage Keyword
+HiLink typescriptDeprecated Exception
+HiLink typescriptError Error
+HiLink typescriptParensError Error
+HiLink typescriptParensErrA Error
+HiLink typescriptParensErrB Error
+HiLink typescriptParensErrC Error
+HiLink typescriptReserved Keyword
+HiLink typescriptOperator Operator
+HiLink typescriptType Type
+HiLink typescriptNull Type
+HiLink typescriptNumber Number
+HiLink typescriptFloat Number
+HiLink typescriptDecorators Special
+HiLink typescriptBoolean Boolean
+HiLink typescriptLabel Label
+HiLink typescriptSpecial Special
+HiLink typescriptSource Special
+HiLink typescriptGlobalObjects Special
+HiLink typescriptGlobalNodeObjects Special
+HiLink typescriptExceptions Special
+
+HiLink typescriptDomErrNo Constant
+HiLink typescriptDomNodeConsts Constant
+HiLink typescriptDomElemAttrs Label
+HiLink typescriptDomElemFuncs PreProc
+
+HiLink typescriptHtmlElemAttrs Label
+HiLink typescriptHtmlElemFuncs PreProc
+
+HiLink typescriptCssStyles Label
+
+" Ajax Highlighting
+HiLink typescriptBrowserObjects Constant
+
+HiLink typescriptDOMObjects Constant
+HiLink typescriptDOMMethods Function
+HiLink typescriptDOMProperties Special
+
+HiLink typescriptAjaxObjects Constant
+HiLink typescriptAjaxMethods Function
+HiLink typescriptAjaxProperties Special
+
+HiLink typescriptFuncDef Title
+HiLink typescriptFuncArg Special
+HiLink typescriptFuncComma Operator
+
+HiLink typescriptHtmlEvents Special
+HiLink typescriptHtmlElemProperties Special
+
+HiLink typescriptEventListenerKeywords Keyword
+
+HiLink typescriptNumber Number
+HiLink typescriptPropietaryObjects Constant
+
+delcommand HiLink
 
 " Define the htmltypescript for HTML syntax html.vim
 "syntax clear htmltypescript


### PR DESCRIPTION
Implements the suggestion posted in:

- https://github.com/leafgarland/typescript-vim/pull/193#issuecomment-1751705278

Which aligns the plugin with what other popular plugins that override bundled syntax files do. eg.

- [plasticboy/vim-markdown](https://github.com/plasticboy/vim-markdown) (uses `hi def link` on version 508 and above)
- [tpope/vim-markdown](https://github.com/tpope/vim-markdown) (uses `hi def link` unconditionally)

This stops highlighting from getting obliterated when activating a colorscheme that uses `:hi clear` (which will reset highlights back to defaults), such as [a Base16 theme](https://github.com/chriskempson/base16-vim/blob/3be3cd82cd31acfcab9a41bad853d9c68d30478d/colors/base16-one-light.vim#L146) or [Dracula](https://github.com/dracula/vim/blob/b2cc39273abbb6b38a3d173d2a5d8c2d1c79fc19/colors/dracula.vim#L19-L24), and presumably others.

May be easier to view with [whitespace changes off](https://github.com/leafgarland/typescript-vim/pull/203/files?w=1).