### PR TITLE
Remove status from typescriptMessage

### DIFF
--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -113,7 +113,7 @@ syntax keyword typescriptStorageClass let var const
 syntax keyword typescriptOperator delete new instanceof typeof
 syntax keyword typescriptBoolean true false
 syntax keyword typescriptNull null undefined
-syntax keyword typescriptMessage alert confirm prompt status
+syntax keyword typescriptMessage alert confirm prompt
 syntax keyword typescriptGlobal self top parent
 syntax keyword typescriptDeprecated escape unescape all applets alinkColor bgColor fgColor linkColor vlinkColor xmlEncoding
 "}}}


### PR DESCRIPTION
`window.status` has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Window/status) for a long time, it's also a common variable name, it feels weird to still have it highlighted and in the same highlight group as `alert` and `confirm`